### PR TITLE
CFIN-152 Change to the openAPI URL for use with the swagger ui

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
   window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
-      url: "https://raw.githubusercontent.com/university-of-york/uoy-app-course-search/master/openapi/openAPI.yml",
+      url: "https://raw.githubusercontent.com/university-of-york/uoy-config-funnelback-courses/master/spec/openAPI.yml",
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [


### PR DESCRIPTION
A folder change meant that the url used by the swagger UI was no longer correct. This commit will change that.