### PR TITLE
CFIN-290: Tidy up Express server configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,9 @@ const app = next({});
 const handle = app.getRequestHandler();
 
 const server = express();
+// serve static assets directly from the build-time-generated ".next" folder
 server.use("/_next", express.static(path.join(__dirname, ".next")));
+// serve all other requests with Next
 server.get("*", (req, res) => handle(req, res));
 
 module.exports = server;

--- a/server.js
+++ b/server.js
@@ -1,8 +1,7 @@
 const express = require("express");
 const path = require("path");
-const dev = process.env.NODE_ENV !== "production";
 const next = require("next");
-const app = next({ dev });
+const app = next({});
 const handle = app.getRequestHandler();
 
 const server = express();


### PR DESCRIPTION
I had originally intended this PR to be about adding an explicit route to `server.js` for the one (so far) dynamic page in the application (index.js) as exemplified in [the Next.js documentation](https://nextjs.org/docs/advanced-features/custom-server). However, after conducting a few experiments with this app and with Christian's demo app, I believe we don't need these explicit routes. The catch-all handler works fine for dynamic pages. The only difference between the explicit route config and the catch-all config is that the former [runs a couple of checks before handing over to the catch-all](https://stackoverflow.com/questions/59971672/custom-next-js-difference-between-getrequesthandler-and-render-functions) - and those checks are not relevant to us. 

I have not made any changes to the Express configuration. Instead I have simply tidied up the code a little, removing unnecessary config for running Next in dev mode (we won't need to do this on AWS) and adding a couple of comments to clarify the existing routes.