### PR TITLE
CFIN-292 Apply the pattern library default layout to the index page

### DIFF
--- a/src/components/PageHead.js
+++ b/src/components/PageHead.js
@@ -1,0 +1,26 @@
+import Head from "next/head";
+import React from "react";
+
+const PageHead = () => {
+    return (
+        <Head>
+            <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="author" content="University of York" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <meta name="description" content="University of York Course search" />
+
+            <title>Course search, University of York</title>
+
+            <link rel="shortcut icon" href="https://www.york.ac.uk/static/stable/img/favicon.ico" />
+            <link rel="icon" type="image/x-icon" href="https://www.york.ac.uk/static/stable/img/favicon.ico" />
+
+            <script src="https://www.york.ac.uk/static/stable/js/modernizr.min.js" />
+            <script src="https://www.york.ac.uk/static/stable/js/app.min.js" />
+
+            <script src="//use.typekit.net/dvj8rpp.js" />
+            <script language="application/javascript">Typekit.load();</script>
+        </Head>
+    );
+};
+
+export { PageHead };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,13 +7,15 @@ import {
 } from "@university-of-york/esg-lib-pattern-library-react-components";
 import { Course } from "../components/Course";
 import { COURSE_MODEL } from "../constants/CourseModel";
+import Head from "next/head";
 require("regenerator-runtime/runtime");
 
 const App = ({ isSuccessfulSearch, searchResults }) => {
     return (
         <>
+            <PageHead />
             <UniversityHeaderWithSearch />
-            <UniversityTitleBar title="Course search results" />
+            <UniversityTitleBar title="Courses" />
 
             <div className="o-wrapper o-wrapper--main o-grid js-wrapper--main">
                 <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />
@@ -27,6 +29,28 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
 App.propTypes = {
     isSuccessfulSearch: PropTypes.bool,
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
+};
+
+const PageHead = () => {
+    return (
+        <Head>
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+            <meta name="author" content="University of York" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <meta name="description" content="University of York Course search" />
+
+            <title>Course search, University of York</title>
+
+            <link rel="shortcut icon" href="https://www.york.ac.uk/static/stable/img/favicon.ico" />
+            <link rel="icon" type="image/x-icon" href="https://www.york.ac.uk/static/stable/img/favicon.ico" />
+
+            <script src="https://www.york.ac.uk/static/stable/js/modernizr.min.js"></script>
+            <script src="https://www.york.ac.uk/static/stable/js/app.min.js"></script>
+
+            <script src="//use.typekit.net/dvj8rpp.js"></script>
+            <script language="application/javascript">Typekit.load();</script>
+        </Head>
+    );
 };
 
 const CourseSearchResults = ({ isSuccessfulSearch, searchResults }) => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,7 +18,11 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
             <UniversityTitleBar title="Courses" />
 
             <div className="o-wrapper o-wrapper--main o-grid js-wrapper--main">
-                <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />
+                <div className="o-grid__row">
+                    <div className="o-grid__box o-grid__box--full">
+                        <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />
+                    </div>
+                </div>
             </div>
 
             <UniversityFooter />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,7 @@ import {
 } from "@university-of-york/esg-lib-pattern-library-react-components";
 import { CourseSearchResults } from "../components/CourseSearchResults";
 import { COURSE_MODEL } from "../constants/CourseModel";
-import Head from "next/head";
+import { PageHead } from "../components/PageHead";
 require("regenerator-runtime/runtime");
 
 const App = ({ isSuccessfulSearch, searchResults }) => {
@@ -29,28 +29,6 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
 App.propTypes = {
     isSuccessfulSearch: PropTypes.bool,
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
-};
-
-const PageHead = () => {
-    return (
-        <Head>
-            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-            <meta name="author" content="University of York" />
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <meta name="description" content="University of York Course search" />
-
-            <title>Course search, University of York</title>
-
-            <link rel="shortcut icon" href="https://www.york.ac.uk/static/stable/img/favicon.ico" />
-            <link rel="icon" type="image/x-icon" href="https://www.york.ac.uk/static/stable/img/favicon.ico" />
-
-            <script src="https://www.york.ac.uk/static/stable/js/modernizr.min.js"></script>
-            <script src="https://www.york.ac.uk/static/stable/js/app.min.js"></script>
-
-            <script src="//use.typekit.net/dvj8rpp.js"></script>
-            <script language="application/javascript">Typekit.load();</script>
-        </Head>
-    );
 };
 
 const getServerSideProps = async () => {

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -9,7 +9,7 @@ describe("App", () => {
     it("displays an appropriate page heading", () => {
         render(<App />);
 
-        expect(screen.getByRole("heading", { name: "Course search results" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Courses" })).toBeInTheDocument();
     });
 
     it("displays the titles from course search results", () => {


### PR DESCRIPTION
This PR goes through the [pattern library layout guide](https://www.york.ac.uk/pattern-library/layout/index.html) and applies some standard tags, page title, favicon etc.

I've also updated the page to use the full [basic grid](https://www.york.ac.uk/pattern-library/layout/grid.html) which gives us the standard responsive layout, which we can then update as we add new components to the page.