### PR TITLE
CFIN-289: Remove regenerator-runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2487,9 +2487,9 @@
             }
         },
         "@university-of-york/esg-lib-pattern-library-react-components": {
-            "version": "4.3.4",
-            "resolved": "https://npm.pkg.github.com/download/@university-of-york/esg-lib-pattern-library-react-components/4.3.4/be828602f1b877135c282447f574ed9d28885866c9ce05953c1164bc5f6ed9cd",
-            "integrity": "sha512-kmsa4RHp/Rj3sKAoXO9cgSoxvdNY2Sr05R5TM/PSNYQhtO8K0w7SDRz1p/5IWtLMhPI/qlXY7dabFuEWpqaPjw==",
+            "version": "4.3.5",
+            "resolved": "https://npm.pkg.github.com/download/@university-of-york/esg-lib-pattern-library-react-components/4.3.5/16ca1fda73b608536e7fc93e2796991ee790100d8ee4d63d9d74b97174df964d",
+            "integrity": "sha512-41420CeeJSnWOqtGg0YJcElZAxokiDJ1uNNWX9L8/iGfwRuTH2jErrj+EaxItq00uL5gzmByX+ISJgPk0w7Nhw==",
             "requires": {
                 "babel-plugin-react-css-modules": "^5.2.6",
                 "html-react-parser": "^0.10.5",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
         "lint": "xo ."
     },
     "dependencies": {
-        "@university-of-york/esg-lib-pattern-library-react-components": "^4.3.4",
+        "@university-of-york/esg-lib-pattern-library-react-components": "^4.3.5",
         "express": "^4.17.1",
         "next": "9.5.3",
         "path-match": "^1.2.4",
         "prop-types": "^15.7.2",
         "react": "16.13.1",
         "react-dom": "16.13.1",
-        "regenerator-runtime": "^0.13.7",
         "serverless-apigw-binary": "^0.4.4",
         "serverless-http": "^2.5.0"
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,6 @@ import {
 } from "@university-of-york/esg-lib-pattern-library-react-components";
 import { Course } from "../components/Course";
 import { COURSE_MODEL } from "../constants/CourseModel";
-require("regenerator-runtime/runtime");
 
 const App = (props) => {
     return (


### PR DESCRIPTION
The ESG React Pattern Library has been updated and now distributes transpiled code so that clients don't have to do it themselves. As a result we no longer need to use regenerator-runtime.