### PR TITLE
CFIN 275 accessibility plugin without eslint plugin

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -1,5 +1,5 @@
 {
-  "extends":["xo-react","prettier","prettier/react"],
+  "extends":["xo-react","prettier","prettier/react","plugin:jsx-a11y/recommended"],
   "overrides":[
     {
       "files":["**/*.test.js","e2e/**","jest/*"],

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -1,4 +1,5 @@
 {
+  "plugins":["jsx-a11y"],
   "extends":["xo-react","prettier","prettier/react","plugin:jsx-a11y/recommended"],
   "overrides":[
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3146,6 +3146,12 @@
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
             "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
         },
+        "ast-types-flow": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+            "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+            "dev": true
+        },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -3184,6 +3190,18 @@
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
             "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+            "dev": true
+        },
+        "axe-core": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+            "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+            "dev": true
+        },
+        "axobject-query": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+            "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
             "dev": true
         },
         "babel-eslint": {
@@ -4713,6 +4731,12 @@
                 "type": "^1.0.1"
             }
         },
+        "damerau-levenshtein": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+            "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
+            "dev": true
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -6016,6 +6040,33 @@
                         "find-up": "^2.0.0",
                         "read-pkg": "^2.0.0"
                     }
+                }
+            }
+        },
+        "eslint-plugin-jsx-a11y": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
+            "integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.10.2",
+                "aria-query": "^4.2.2",
+                "array-includes": "^3.1.1",
+                "ast-types-flow": "^0.0.7",
+                "axe-core": "^3.5.4",
+                "axobject-query": "^2.1.2",
+                "damerau-levenshtein": "^1.0.6",
+                "emoji-regex": "^9.0.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.4.1",
+                "language-tags": "^1.0.5"
+            },
+            "dependencies": {
+                "emoji-regex": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+                    "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+                    "dev": true
                 }
             }
         },
@@ -9753,6 +9804,21 @@
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
             "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true
+        },
+        "language-subtag-registry": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
+            "integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+            "dev": true
+        },
+        "language-tags": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+            "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+            "dev": true,
+            "requires": {
+                "language-subtag-registry": "~0.3.2"
+            }
         },
         "latest-version": {
             "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "dotenv": "^8.2.0",
         "eslint-config-xo-nextjs": "^1.6.0",
         "eslint-config-xo-react": "^0.23.0",
+        "eslint-plugin-jsx-a11y": "^6.3.1",
         "eslint-plugin-react": "^7.20.6",
         "eslint-plugin-react-hooks": "^4.1.2",
         "jest": "^26.4.2",


### PR DESCRIPTION
Following a comment this branch does not have eslint installed as part of the eslint-plugin-jsx-a11y install.