### PR TITLE
CFIN-276 Retrieve assets from the correct URLs when running in API Gateway

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+const isProd = process.env.NODE_ENV === 'production'
+
+module.exports = {
+  // Use the CDN in production and localhost for development.
+  assetPrefix: isProd ? '/v1' : '',
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const isProd = process.env.NODE_ENV === 'production'
 
 module.exports = {
-  // Retrieve assets from the correct API Gateway Stage in AWS.
+  // Retrieve assets from the correct URL that accounts for the Stage when running in AWS API Gateway.
   assetPrefix: isProd ? '/v1' : '',
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const isProd = process.env.NODE_ENV === 'production'
 
 module.exports = {
-  // Use the CDN in production and localhost for development.
+  // Retrieve assets from the correct API Gateway Stage in AWS.
   assetPrefix: isProd ? '/v1' : '',
 }


### PR DESCRIPTION
This is a small change to make Next account for the Stage in the AWS API Gateway URL when retrieving assets. I followed [these instructions in the Next documentation](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix).

We might be able to remove this once we configure a stable domain name.