### PR TITLE
CFIN-299: Amend 'check' command to check formatting rather than fixing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write .",
     "checkformat": "prettier --check .",
     "lint": "xo .",
-    "check": "npm run format && npm run lint && npm run test"
+    "check": "npm run checkformat && npm run lint && npm run test"
   },
   "dependencies": {
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "checkformat": "prettier --check .",
     "lint": "xo .",
-    "check": "npm run checkformat && npm run lint && npm run test"
+    "check": "npm run checkformat && npm run lint && npm run test",
+    "formatandcheck": "npm run format && npm run lint && npm run test"
   },
   "dependencies": {
     "express": "^4.17.1",


### PR DESCRIPTION
Also adds a command `formatandcheck` that replaces the previous behaviour of `check`.