### PR TITLE
CFIN-312 Update workflow and severless to use custom domain/URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
           AWS_ACCOUNT_ID: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
           DEPLOY_ENVIRONMENT: dev
+          SSL_CERTIFICATE_ARN: ${{ secrets.DEV_SSL_CERTIFICATE_ARN }}
+          DOMAIN_NAME: courses.dev.app.york.ac.uk
 
       - name: Deploy - production
         if: github.ref == 'refs/heads/main'
@@ -53,3 +55,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
           AWS_ACCOUNT_ID: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
           DEPLOY_ENVIRONMENT: prod
+          SSL_CERTIFICATE_ARN: ${{ secrets.PRODUCTION_SSL_CERTIFICATE_ARN }}
+          DOMAIN_NAME: courses.app.york.ac.uk

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,0 @@
-const isProd = process.env.NODE_ENV === "production";
-
-module.exports = {
-    // Retrieve assets from the correct URL that accounts for the Stage when running in AWS API Gateway.
-    assetPrefix: isProd ? "/v1" : "",
-};

--- a/serverless.yml
+++ b/serverless.yml
@@ -75,15 +75,13 @@ package:
     - node_modules/micromatch/**
 
 resources:
-
   Conditions:
     UseCustomDomainName: !Not
       - !Equals
         - ${self:custom.domainName}
-        - ''
+        - ""
 
   Resources:
-
     ApiGatewayCustomDomainName:
       Type: AWS::ApiGateway::DomainName
       Condition: UseCustomDomainName
@@ -99,7 +97,7 @@ resources:
       Condition: UseCustomDomainName
       DependsOn: ApiGatewayDeployment${sls:instanceId}
       Properties:
-        BasePath: ''
+        BasePath: ""
         DomainName: !Ref ApiGatewayCustomDomainName
         RestApiId: !Ref ApiGatewayRestApi
         Stage: ${self:provider.stage}
@@ -110,4 +108,4 @@ resources:
       Properties:
         ServiceToken: arn:aws:sns:eu-west-1:230504789214:RequestRecordSet
         Source: ${self:custom.domainName}.
-        Target: !Join [ '', [ !GetAtt ApiGatewayCustomDomainName.RegionalDomainName, '.' ] ]
+        Target: !Join ["", [!GetAtt ApiGatewayCustomDomainName.RegionalDomainName, "."]]

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,6 +34,8 @@ custom:
   apigwBinary:
     types:
       - "*/*"
+  domainName: ${env:DOMAIN_NAME, ''}
+  sslCertificateArn: ${env:SSL_CERTIFICATE_ARN, ''}
 
 # Exclude next.js dependencies that are not needed at runtime
 package:

--- a/serverless.yml
+++ b/serverless.yml
@@ -73,3 +73,41 @@ package:
     - node_modules/ext/**
     - node_modules/tr46/**
     - node_modules/micromatch/**
+
+resources:
+
+  Conditions:
+    UseCustomDomainName: !Not
+      - !Equals
+        - ${self:custom.domainName}
+        - ''
+
+  Resources:
+
+    ApiGatewayCustomDomainName:
+      Type: AWS::ApiGateway::DomainName
+      Condition: UseCustomDomainName
+      Properties:
+        RegionalCertificateArn: ${self:custom.sslCertificateArn}
+        DomainName: ${self:custom.domainName}
+        EndpointConfiguration:
+          Types:
+            - REGIONAL
+
+    BasePathMapping:
+      Type: AWS::ApiGateway::BasePathMapping
+      Condition: UseCustomDomainName
+      DependsOn: ApiGatewayDeployment${sls:instanceId}
+      Properties:
+        BasePath: ''
+        DomainName: !Ref ApiGatewayCustomDomainName
+        RestApiId: !Ref ApiGatewayRestApi
+        Stage: ${self:provider.stage}
+
+    AppCNAME:
+      Type: Custom::CNAME
+      Condition: UseCustomDomainName
+      Properties:
+        ServiceToken: arn:aws:sns:eu-west-1:230504789214:RequestRecordSet
+        Source: ${self:custom.domainName}.
+        Target: !Join [ '', [ !GetAtt ApiGatewayCustomDomainName.RegionalDomainName, '.' ] ]


### PR DESCRIPTION
Spoke to Chris earlier and for now we're going to use courses.app.york.ac.uk. This is to prevent people finding the prototype and getting confused by its lack of functionality before first release.