### PR TITLE
CFIN-123 use the latest React pattern library, and refactor to use components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,9 +3408,9 @@
       }
     },
     "@university-of-york/esg-lib-pattern-library-react-components": {
-      "version": "4.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@university-of-york/esg-lib-pattern-library-react-components/4.3.5/16ca1fda73b608536e7fc93e2796991ee790100d8ee4d63d9d74b97174df964d",
-      "integrity": "sha512-41420CeeJSnWOqtGg0YJcElZAxokiDJ1uNNWX9L8/iGfwRuTH2jErrj+EaxItq00uL5gzmByX+ISJgPk0w7Nhw==",
+      "version": "5.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@university-of-york/esg-lib-pattern-library-react-components/5.0.1/bde35e44635a584b87d34feb63614089f8a51c15651d2d5f204d9f468511f954",
+      "integrity": "sha512-E2I1HrVkE/atRNhfZe76z2iT/2snkpdakEimusGVFIGFJTMB+BtH7UrQBRWtFHsuHrTRRWOQ88Ln8UQMOM7cRw==",
       "requires": {
         "babel-plugin-react-css-modules": "^5.2.6",
         "html-react-parser": "^0.10.5",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "formatandcheck": "npm run format && npm run lint && npm run test"
   },
   "dependencies": {
-    "@university-of-york/esg-lib-pattern-library-react-components": "^4.3.5",
+    "@university-of-york/esg-lib-pattern-library-react-components": "^5.0.0",
     "express": "^4.17.1",
     "next": "9.5.3",
     "path-match": "^1.2.4",
+    "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "serverless-apigw-binary": "^0.4.4",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {
+    GridBoxFull,
+    GridRow,
     UniversityFooter,
     UniversityHeaderWithSearch,
     UniversityTitleBar,
+    WrappedMainGrid,
 } from "@university-of-york/esg-lib-pattern-library-react-components";
 import { CourseSearchResults } from "../components/CourseSearchResults";
 import { COURSE_MODEL } from "../constants/CourseModel";
@@ -16,13 +19,13 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
             <UniversityHeaderWithSearch />
             <UniversityTitleBar title="Courses" />
 
-            <div className="o-wrapper o-wrapper--main o-grid js-wrapper--main">
-                <div className="o-grid__row">
-                    <div className="o-grid__box o-grid__box--full">
+            <WrappedMainGrid>
+                <GridRow>
+                    <GridBoxFull>
                         <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />
-                    </div>
-                </div>
-            </div>
+                    </GridBoxFull>
+                </GridRow>
+            </WrappedMainGrid>
 
             <UniversityFooter />
         </>


### PR DESCRIPTION
This is a small change to use the latest version of the React pattern library which fixes the padding of the title bar (see [the PR](https://github.com/university-of-york/esg-lib-pattern-library-react-components/pull/18) for details).

I've also refactored to use some of the library components rather than our own `div`s where possible, and reintroduced the `prop-types` library which mysteriously vanished.

I would have liked to refactor the `SearchFailedMessage` to use an `Alert` component from the React pattern library, but it looks like they only exist for `Error` and `Success` at the moment, and not `Warning` which is what we use - a good candidate for someone to do in some downtime :smiley: 