### PR TITLE
CFIN-303 allow users to enter a search term

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.17.1",
     "next": "9.5.3",
     "path-match": "^1.2.4",
+    "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "serverless-apigw-binary": "^0.4.4",

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,0 +1,38 @@
+import {
+    FormElement,
+    FormFieldset,
+    FormInputText,
+    Grid,
+    GridBoxFull,
+    GridRow,
+    SearchIcon,
+} from "@university-of-york/esg-lib-pattern-library-react-components";
+import React from "react";
+
+const Search = () => {
+    return (
+        <form autoComplete="off" method="get" className="c-form c-form--joined" role="search" aria-label="Courses">
+            <FormFieldset>
+                <Grid>
+                    <GridRow>
+                        <GridBoxFull>
+                            <FormElement>
+                                <FormInputText
+                                    name="search"
+                                    type="text"
+                                    ariaLabel="Search"
+                                    placeholder="Search for your course"
+                                />
+                                <button className="c-btn c-btn--medium" type="submit" aria-label="Search">
+                                    <SearchIcon />
+                                </button>
+                            </FormElement>
+                        </GridBoxFull>
+                    </GridRow>
+                </Grid>
+            </FormFieldset>
+        </form>
+    );
+};
+
+export { Search };

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -8,8 +8,9 @@ import {
     SearchIcon,
 } from "@university-of-york/esg-lib-pattern-library-react-components";
 import React from "react";
+import PropTypes from "prop-types";
 
-const Search = () => {
+const Search = ({ searchTerm }) => {
     return (
         <form autoComplete="off" method="get" className="c-form c-form--joined" role="search" aria-label="Courses">
             <FormFieldset>
@@ -22,6 +23,7 @@ const Search = () => {
                                     type="text"
                                     ariaLabel="Search"
                                     placeholder="Search for your course"
+                                    defaultValue={searchTerm}
                                 />
                                 <button className="c-btn c-btn--medium" type="submit" aria-label="Search">
                                     <SearchIcon />
@@ -33,6 +35,10 @@ const Search = () => {
             </FormFieldset>
         </form>
     );
+};
+
+Search.propTypes = {
+    searchTerm: PropTypes.string,
 };
 
 export { Search };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,13 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {
-    FormElement,
-    FormFieldset,
-    FormInputText,
-    Grid,
     GridBoxFull,
     GridRow,
-    SearchIcon,
     UniversityFooter,
     UniversityHeaderWithSearch,
     UniversityTitleBar,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,6 +48,7 @@ const getServerSideProps = async (context) => {
     const searchTerm = context.query.search ? context.query.search : "maths";
 
     const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}`;
+
     let isSuccessfulSearch;
     let searchResponseData;
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ import { COURSE_MODEL } from "../constants/CourseModel";
 import { PageHead } from "../components/PageHead";
 import { Search } from "../components/Search";
 
-const App = ({ isSuccessfulSearch, searchResults }) => {
+const App = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
     return (
         <>
             <PageHead />
@@ -23,7 +23,7 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
             <WrappedMainGrid>
                 <GridRow>
                     <GridBoxFull>
-                        <Search />
+                        <Search searchTerm={searchTerm} />
                     </GridBoxFull>
                 </GridRow>
                 <GridRow>
@@ -41,10 +41,13 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
 App.propTypes = {
     isSuccessfulSearch: PropTypes.bool,
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
+    searchTerm: PropTypes.string,
 };
 
-const getServerSideProps = async () => {
-    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=maths`;
+const getServerSideProps = async (context) => {
+    const searchTerm = context.query.search ? context.query.search : "maths";
+
+    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}`;
     let isSuccessfulSearch;
     let searchResponseData;
 
@@ -57,7 +60,7 @@ const getServerSideProps = async () => {
         searchResponseData = { results: [] };
     }
 
-    return { props: { isSuccessfulSearch, searchResults: searchResponseData.results } };
+    return { props: { isSuccessfulSearch, searchResults: searchResponseData.results, searchTerm } };
 };
 
 export { App as default, getServerSideProps };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {
+    FormElement,
+    FormFieldset,
+    FormInputText,
+    Grid,
+    GridBoxFull,
+    GridRow,
+    SearchIcon,
     UniversityFooter,
     UniversityHeaderWithSearch,
     UniversityTitleBar,
@@ -17,6 +24,37 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
             <UniversityTitleBar title="Courses" />
 
             <div className="o-wrapper o-wrapper--main o-grid js-wrapper--main">
+                <GridRow>
+                    <GridBoxFull>
+                        <form
+                            autoComplete="off"
+                            method="get"
+                            className="c-form c-form--joined"
+                            role="search"
+                            aria-label="Courses"
+                        >
+                            <FormFieldset>
+                                <Grid>
+                                    <GridRow>
+                                        <GridBoxFull>
+                                            <FormElement>
+                                                <FormInputText name="search" type="text" ariaLabel="Search" />
+                                                <button
+                                                    className="c-btn c-btn--medium"
+                                                    type="submit"
+                                                    aria-label="Search"
+                                                >
+                                                    <SearchIcon />
+                                                </button>
+                                            </FormElement>
+                                        </GridBoxFull>
+                                    </GridRow>
+                                </Grid>
+                            </FormFieldset>
+                        </form>
+                    </GridBoxFull>
+                </GridRow>
+
                 <div className="o-grid__row">
                     <div className="o-grid__box o-grid__box--full">
                         <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,7 +38,7 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
                                     <GridRow>
                                         <GridBoxFull>
                                             <FormElement>
-                                                <FormInputText name="search" type="text" ariaLabel="Search" />
+                                                <FormInputText name="search" type="text" ariaLabel="Search" placeholder="Search for your course" />
                                                 <button
                                                     className="c-btn c-btn--medium"
                                                     type="submit"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,7 @@ App.propTypes = {
 };
 
 const getServerSideProps = async (context) => {
-    const searchTerm = context.query.search ? context.query.search : "maths";
+    const searchTerm = context.query.search || "maths";
 
     const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}`;
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,6 +15,7 @@ import {
 import { CourseSearchResults } from "../components/CourseSearchResults";
 import { COURSE_MODEL } from "../constants/CourseModel";
 import { PageHead } from "../components/PageHead";
+import { Search } from "../components/Search";
 
 const App = ({ isSuccessfulSearch, searchResults }) => {
     return (
@@ -26,35 +27,9 @@ const App = ({ isSuccessfulSearch, searchResults }) => {
             <div className="o-wrapper o-wrapper--main o-grid js-wrapper--main">
                 <GridRow>
                     <GridBoxFull>
-                        <form
-                            autoComplete="off"
-                            method="get"
-                            className="c-form c-form--joined"
-                            role="search"
-                            aria-label="Courses"
-                        >
-                            <FormFieldset>
-                                <Grid>
-                                    <GridRow>
-                                        <GridBoxFull>
-                                            <FormElement>
-                                                <FormInputText name="search" type="text" ariaLabel="Search" placeholder="Search for your course" />
-                                                <button
-                                                    className="c-btn c-btn--medium"
-                                                    type="submit"
-                                                    aria-label="Search"
-                                                >
-                                                    <SearchIcon />
-                                                </button>
-                                            </FormElement>
-                                        </GridBoxFull>
-                                    </GridRow>
-                                </Grid>
-                            </FormFieldset>
-                        </form>
+                        <Search />
                     </GridBoxFull>
                 </GridRow>
-
                 <div className="o-grid__row">
                     <div className="o-grid__box o-grid__box--full">
                         <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />

--- a/src/tests/components/Search.test.js
+++ b/src/tests/components/Search.test.js
@@ -1,0 +1,18 @@
+import { render, screen, within } from "@testing-library/react";
+import {Search} from "../../components/Search";
+
+describe("Search", () => {
+
+    it("displays a search input and button", () => {
+        render(<Search />);
+
+        const search = screen.getByRole("search", { name: "Courses" });
+
+        expect(search).toBeVisible();
+
+        const { getByRole } = within(search);
+
+        expect(getByRole("textbox", { name: "Search" })).toBeVisible();
+        expect(getByRole("button", { name: "Search" })).toBeVisible();
+    });
+});

--- a/src/tests/components/Search.test.js
+++ b/src/tests/components/Search.test.js
@@ -14,4 +14,12 @@ describe("Search", () => {
         expect(getByRole("textbox", { name: "Search" })).toBeVisible();
         expect(getByRole("button", { name: "Search" })).toBeVisible();
     });
+
+    it("populates the search box with the search term", () => {
+        render(<Search searchTerm="French" />);
+
+        const { getByRole } = within(screen.getByRole("search", { name: "Courses" }));
+
+        expect(getByRole("textbox", { name: "Search" }).value).toEqual("French");
+    });
 });

--- a/src/tests/components/Search.test.js
+++ b/src/tests/components/Search.test.js
@@ -1,8 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
-import {Search} from "../../components/Search";
+import { Search } from "../../components/Search";
 
 describe("Search", () => {
-
     it("displays a search input and button", () => {
         render(<Search />);
 

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import App, { getServerSideProps } from "../../pages";
 
 beforeEach(() => {

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -12,17 +12,10 @@ describe("App", () => {
         expect(screen.getByRole("heading", { name: "Courses" })).toBeInTheDocument();
     });
 
-    it("displays the search element with a search input and button", () => {
+    it("displays the search element", () => {
         render(<App />);
 
-        const courseSearchBox = screen.getByRole("search", { name: "Courses" });
-
-        expect(courseSearchBox).toBeVisible();
-
-        const { getByRole } = within(courseSearchBox);
-
-        expect(getByRole("textbox", { name: "Search" })).toBeInTheDocument();
-        expect(getByRole("button", { name: "Search" }));
+        expect(screen.getByRole("search", { name: "Courses" })).toBeVisible();
     });
 
     it("displays the titles from course search results", () => {

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import App, { getServerSideProps } from "../../pages";
 
 beforeEach(() => {
@@ -10,6 +10,19 @@ describe("App", () => {
         render(<App />);
 
         expect(screen.getByRole("heading", { name: "Courses" })).toBeInTheDocument();
+    });
+
+    it("displays the search element with a search input and button", () => {
+        render(<App />);
+
+        const courseSearchBox = screen.getByRole("search", { name: "Courses" });
+
+        expect(courseSearchBox).toBeVisible();
+
+        const { getByRole } = within(courseSearchBox);
+
+        expect(getByRole("textbox", { name: "Search" })).toBeInTheDocument();
+        expect(getByRole("button", { name: "Search" }));
     });
 
     it("displays the titles from course search results", () => {

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -5,6 +5,8 @@ beforeEach(() => {
     fetch.resetMocks();
 });
 
+const emptyContext = { query: {} };
+
 describe("App", () => {
     it("displays an appropriate page heading", () => {
         render(<App />);
@@ -37,51 +39,44 @@ describe("getServerSideProps", () => {
             JSON.stringify({
                 results: [
                     {
-                        title: "Maths",
+                        title: "English",
                     },
                 ],
             })
         );
 
-        const response = await getServerSideProps();
+        const response = await getServerSideProps({ query: { search: "english" } });
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith("https://test.courses.api.com?search=english");
+
+        expect(response.props.isSuccessfulSearch).toEqual(true);
+        expect(response.props.searchResults).toEqual([{ title: "English" }]);
+        expect(response.props.searchTerm).toEqual("english");
+    });
+
+    it("calls the Courses API with a default search term when none is entered", async () => {
+        await getServerSideProps(emptyContext);
 
         expect(fetch).toHaveBeenCalledTimes(1);
         expect(fetch).toHaveBeenCalledWith("https://test.courses.api.com?search=maths");
-        expect(response).toEqual({
-            props: {
-                isSuccessfulSearch: true,
-                searchResults: [
-                    {
-                        title: "Maths",
-                    },
-                ],
-            },
-        });
     });
 
     it("indicates when the Courses API search failed (http error response)", async () => {
         fetch.mockResponse("{}", { status: 500 });
 
-        const response = await getServerSideProps();
+        const response = await getServerSideProps(emptyContext);
 
-        expect(response).toEqual({
-            props: {
-                isSuccessfulSearch: false,
-                searchResults: [],
-            },
-        });
+        expect(response.props.isSuccessfulSearch).toEqual(false);
+        expect(response.props.searchResults).toEqual([]);
     });
 
     it("indicates when the Courses API search failed (network or other error)", async () => {
         fetch.mockReject(new Error("can not resolve host"));
 
-        const response = await getServerSideProps();
+        const response = await getServerSideProps(emptyContext);
 
-        expect(response).toEqual({
-            props: {
-                isSuccessfulSearch: false,
-                searchResults: [],
-            },
-        });
+        expect(response.props.isSuccessfulSearch).toEqual(false);
+        expect(response.props.searchResults).toEqual([]);
     });
 });


### PR DESCRIPTION
This change adds a search box and basic search functionality to Course Search. You can try it out in my AWS sandbox account at https://y3cdpz4cgk.execute-api.eu-west-1.amazonaws.com/v1.

If a search term hasn't been entered it uses a default one for now - there's a separate story [CFIN-253](https://jira.york.ac.uk/browse/CFIN-253) about seeing a sensible list of courses when not entering a search term.

The following will be covered in separate PRs:
- Adding a sensible message when no search results are returned.
- Accessibility checks

---

![cfin-303](https://user-images.githubusercontent.com/59824795/95328577-a79e7700-089d-11eb-8e08-b41523e1c3b0.png)