### PR TITLE
CFIN-307: Create re-usable tag component

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -14,6 +14,9 @@
     "import/no-unassigned-import": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-no-useless-fragment": "off",
+    "react/self-closing-comp": ["error", {
+      "html": false
+    }],
     "unicorn/filename-case": "off",
     "unicorn/import-index": "off",
     "unicorn/prevent-abbreviations": "off"

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -14,12 +14,6 @@
     "import/no-unassigned-import": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-no-useless-fragment": "off",
-    "react/self-closing-comp": [
-      "error",
-      {
-        "html": false
-      }
-    ],
     "unicorn/filename-case": "off",
     "unicorn/import-index": "off",
     "unicorn/prevent-abbreviations": "off"

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -14,9 +14,12 @@
     "import/no-unassigned-import": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-no-useless-fragment": "off",
-    "react/self-closing-comp": ["error", {
-      "html": false
-    }],
+    "react/self-closing-comp": [
+      "error",
+      {
+        "html": false
+      }
+    ],
     "unicorn/filename-case": "off",
     "unicorn/import-index": "off",
     "unicorn/prevent-abbreviations": "off"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.17.1",
     "next": "9.5.3",
     "path-match": "^1.2.4",
+    "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "serverless-apigw-binary": "^0.4.4",

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -6,7 +6,7 @@ const Tag = ({ icon, mainText }) => (
         <span className="c-tag">
             <i aria-hidden className={`c-tag__icon c-icon c-icon--${icon}`} data-testid="tag-icon" />
             {mainText}
-        </span>
+        </span>{" "}
     </li>
 );
 

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -6,7 +6,7 @@ const Tag = ({ icon, mainText }) => (
         <span className="c-tag">
             <i aria-hidden className={`c-tag__icon c-icon c-icon--${icon}`} data-testid="tag-icon" />
             {mainText}
-        </span>{" "}
+        </span>
     </li>
 );
 

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -6,7 +6,7 @@ const Tag = ({ icon, mainText }) => (
         <span className="c-tag">
             <i aria-hidden className={`c-tag__icon c-icon c-icon--${icon}`} data-testid="tag-icon"></i>
             {mainText}
-        </span>
+        </span>{" "}
     </li>
 );
 

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+const Tag = ({ icon, mainText }) => (
+    <li className="c-tag-list__item">
+        <span className="c-tag">
+            <i aria-hidden className={`c-tag__icon c-icon c-icon--${icon}`} data-testid="tag-icon"></i>
+            {mainText}
+        </span>
+    </li>
+);
+
+Tag.propTypes = {
+    icon: PropTypes.string.isRequired,
+    mainText: PropTypes.string.isRequired,
+};
+
+export { Tag };

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -11,7 +11,7 @@ const Tag = ({ icon, mainText }) => (
 );
 
 Tag.propTypes = {
-    icon: PropTypes.string.isRequired,
+    icon: PropTypes.string,
     mainText: PropTypes.string.isRequired,
 };
 

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -4,7 +4,7 @@ import React from "react";
 const Tag = ({ icon, mainText }) => (
     <li className="c-tag-list__item">
         <span className="c-tag">
-            <i aria-hidden className={`c-tag__icon c-icon c-icon--${icon}`} data-testid="tag-icon"></i>
+            <i aria-hidden className={`c-tag__icon c-icon c-icon--${icon}`} data-testid="tag-icon" />
             {mainText}
         </span>{" "}
     </li>

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -1,17 +1,19 @@
 import React from "react";
 
-const TagList = ({ tags }) => {
+const TagList = ({ items }) => {
     return (
         <ul>
-            {tags.map((item) => {
-                return (
-                    <li key={item} aria-labelledby={`${item}-tag`}>
-                        <span id={`${item}-tag`}>{item}</span>
-                    </li>
-                );
-            })}
+            {items.map((item) => (
+                <Tag key={item} name={item} />
+            ))}
         </ul>
     );
 };
+
+const Tag = ({ name }) => (
+    <li aria-labelledby={`${name}-tag`}>
+        <span id={`${name}-tag`}>{name}</span>
+    </li>
+);
 
 export { TagList };

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -1,30 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const TagList = ({ items }) => {
-    return (
-        <ul className="c-tag-list">
-            {items.map((item) => (
-                <Tag key={item} name={item} />
-            ))}
-        </ul>
-    );
+const TagList = (props) => {
+    return <ul className="c-tag-list">{props.children}</ul>;
 };
 
 TagList.propTypes = {
-    items: PropTypes.arrayOf(PropTypes.string),
-};
-
-const Tag = ({ name }) => (
-    <li className="c-tag-list__item" aria-labelledby={`${name}-tag`}>
-        <span className="c-tag" id={`${name}-tag`}>
-            {name}
-        </span>
-    </li>
-);
-
-Tag.propTypes = {
-    name: PropTypes.string,
+    children: PropTypes.node,
 };
 
 export { TagList };

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 const TagList = ({ items }) => {
     return (
-        <ul>
+        <ul className="c-tag-list">
             {items.map((item) => (
                 <Tag key={item} name={item} />
             ))}
@@ -16,8 +16,10 @@ TagList.propTypes = {
 };
 
 const Tag = ({ name }) => (
-    <li aria-labelledby={`${name}-tag`}>
-        <span id={`${name}-tag`}>{name}</span>
+    <li className="c-tag-list__item" aria-labelledby={`${name}-tag`}>
+        <span className="c-tag" id={`${name}-tag`}>
+            {name}
+        </span>
     </li>
 );
 

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -6,7 +6,7 @@ const TagList = (props) => {
 };
 
 TagList.propTypes = {
-    children: PropTypes.node,
+    children: PropTypes.node.isRequired,
 };
 
 export { TagList };

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const TagList = ({ items }) => {
     return (
@@ -10,10 +11,18 @@ const TagList = ({ items }) => {
     );
 };
 
+TagList.propTypes = {
+    items: PropTypes.arrayOf(PropTypes.string),
+};
+
 const Tag = ({ name }) => (
     <li aria-labelledby={`${name}-tag`}>
         <span id={`${name}-tag`}>{name}</span>
     </li>
 );
+
+Tag.propTypes = {
+    name: PropTypes.string,
+};
 
 export { TagList };

--- a/src/components/TagList.js
+++ b/src/components/TagList.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+const TagList = ({ tags }) => {
+    return (
+        <ul>
+            {tags.map((item) => {
+                return (
+                    <li key={item} aria-labelledby={`${item}-tag`}>
+                        <span id={`${item}-tag`}>{item}</span>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+};
+
+export { TagList };

--- a/src/tests/components/Tag.test.js
+++ b/src/tests/components/Tag.test.js
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { Tag } from "../../components/Tag";
+import React from "react";
+
+describe("Tag", () => {
+    it("displays tag containing given icon and text", () => {
+        render(<Tag icon="battery-full" mainText="Battery is full" />);
+
+        expect(screen.getByRole("listitem")).toHaveTextContent("Battery is full");
+        expect(screen.getByRole("listitem")).toContainElement(screen.getByTestId("tag-icon"));
+        expect(screen.getByTestId("tag-icon")).toHaveClass("c-icon--battery-full");
+    });
+});

--- a/src/tests/components/Tag.test.js
+++ b/src/tests/components/Tag.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { Tag } from "../../components/Tag";
 import React from "react";
 
@@ -6,8 +6,8 @@ describe("Tag", () => {
     it("displays tag containing given icon and text", () => {
         render(<Tag icon="battery-full" mainText="Battery is full" />);
 
-        expect(screen.getByRole("listitem")).toHaveTextContent("Battery is full");
-        expect(screen.getByRole("listitem")).toContainElement(screen.getByTestId("tag-icon"));
-        expect(screen.getByTestId("tag-icon")).toHaveClass("c-icon--battery-full");
+        const tag = screen.getByRole("listitem");
+        expect(tag).toHaveTextContent("Battery is full");
+        expect(within(tag).getByTestId("tag-icon")).toHaveClass("c-icon--battery-full");
     });
 });

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -1,17 +1,31 @@
 import { render, screen } from "@testing-library/react";
 import { TagList } from "../../components/TagList";
+import { Tag } from "../../components/Tag";
 import React from "react";
 
-describe("CourseSearchResults", () => {
+describe("TagList", () => {
     it("displays tags labelled with given inputs", () => {
-        render(<TagList items={["foo", "bar"]} />);
+        render(
+            <TagList>
+                <Tag icon="clock" mainText="foo bar" />
+                <Tag icon="key" mainText="fruit salad" />
+            </TagList>
+        );
 
-        expect(screen.getByRole("listitem", { name: "foo" })).toBeInTheDocument();
-        expect(screen.getByRole("listitem", { name: "bar" })).toBeInTheDocument();
+        const items = screen.getAllByRole("listitem");
+        const icons = screen.getAllByTestId("tag-icon");
+
+        expect(items[0]).toHaveTextContent("foo bar");
+        expect(items[0]).toContainElement(icons[0]);
+        expect(icons[0]).toHaveClass("c-icon--clock");
+
+        expect(items[1]).toHaveTextContent("fruit salad");
+        expect(items[1]).toContainElement(icons[1]);
+        expect(icons[1]).toHaveClass("c-icon--key");
     });
 
     it("displays no tags when given no inputs", () => {
-        render(<TagList items={[]} />);
+        render(<TagList />);
 
         expect(screen.queryByRole("listitem")).toBeNull();
     });

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { TagList } from "../../components/TagList";
 import { Tag } from "../../components/Tag";
 import React from "react";
@@ -12,16 +12,13 @@ describe("TagList", () => {
             </TagList>
         );
 
-        const items = screen.getAllByRole("listitem");
-        const icons = screen.getAllByTestId("tag-icon");
+        const tags = screen.getAllByRole("listitem");
 
-        expect(items[0]).toHaveTextContent("foo bar");
-        expect(items[0]).toContainElement(icons[0]);
-        expect(icons[0]).toHaveClass("c-icon--clock");
+        expect(tags[0]).toHaveTextContent("foo bar");
+        expect(within(tags[0]).getByTestId("tag-icon")).toHaveClass("c-icon--clock");
 
-        expect(items[1]).toHaveTextContent("fruit salad");
-        expect(items[1]).toContainElement(icons[1]);
-        expect(icons[1]).toHaveClass("c-icon--key");
+        expect(tags[1]).toHaveTextContent("fruit salad");
+        expect(within(tags[1]).getByTestId("tag-icon")).toHaveClass("c-icon--key");
     });
 
     it("displays no tags when given no inputs", () => {

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { TagList } from "../../components/TagList";
+import React from "react";
+
+describe("CourseSearchResults", () => {
+    it("displays tags labelled with given inputs", () => {
+        render(<TagList tags={["foo", "bar"]} />);
+
+        expect(screen.getByRole("listitem", { name: "foo" })).toBeInTheDocument();
+        expect(screen.getByRole("listitem", { name: "bar" })).toBeInTheDocument();
+    });
+});

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -7,7 +7,7 @@ describe("TagList", () => {
     it("displays tags labelled with given inputs", () => {
         render(
             <TagList>
-                <Tag icon="clock" mainText="foo bar" />
+                <Tag icon="institution" mainText="foo bar" />
                 <Tag icon="key" mainText="fruit salad" />
             </TagList>
         );
@@ -15,7 +15,7 @@ describe("TagList", () => {
         const tags = screen.getAllByRole("listitem");
 
         expect(tags[0]).toHaveTextContent("foo bar");
-        expect(within(tags[0]).getByTestId("tag-icon")).toHaveClass("c-icon--clock");
+        expect(within(tags[0]).getByTestId("tag-icon")).toHaveClass("c-icon--institution");
 
         expect(tags[1]).toHaveTextContent("fruit salad");
         expect(within(tags[1]).getByTestId("tag-icon")).toHaveClass("c-icon--key");

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -9,4 +9,10 @@ describe("CourseSearchResults", () => {
         expect(screen.getByRole("listitem", { name: "foo" })).toBeInTheDocument();
         expect(screen.getByRole("listitem", { name: "bar" })).toBeInTheDocument();
     });
+
+    it("displays no tags when given no inputs", () => {
+        render(<TagList items={[]} />);
+
+        expect(screen.queryByRole("listitem")).toBeNull();
+    });
 });

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -20,10 +20,4 @@ describe("TagList", () => {
         expect(tags[1]).toHaveTextContent("fruit salad");
         expect(within(tags[1]).getByTestId("tag-icon")).toHaveClass("c-icon--key");
     });
-
-    it("displays no tags when given no inputs", () => {
-        render(<TagList />);
-
-        expect(screen.queryByRole("listitem")).toBeNull();
-    });
 });

--- a/src/tests/components/TagList.test.js
+++ b/src/tests/components/TagList.test.js
@@ -4,7 +4,7 @@ import React from "react";
 
 describe("CourseSearchResults", () => {
     it("displays tags labelled with given inputs", () => {
-        render(<TagList tags={["foo", "bar"]} />);
+        render(<TagList items={["foo", "bar"]} />);
 
         expect(screen.getByRole("listitem", { name: "foo" })).toBeInTheDocument();
         expect(screen.getByRole("listitem", { name: "bar" })).toBeInTheDocument();


### PR DESCRIPTION
This PR adds components `<TagList>` and `<Tag>`. The tag includes an `icon` parameter which aligns with the latest designs. These components could be used like 
```
<TagList>
    <Tag icon="clock" mainText="Start September 2021" />
    <Tag icon="graduation-cap" mainText="Undergraduate />
</TagList>
```
although I imagine that we'll want to [specialise](https://reactjs.org/docs/composition-vs-inheritance.html#specialization) the `<Tag>` component and create `<AwardTag>` and `<StartDateTag>` so that ultimately we use tags more like
```
<TagList>
    <StartDateTag year="2021" />
    <AwardTag award="BSc" />
</TagList>
```
and `<AwardTag>`, for example, will make use of the generic `<Tag>`:
```
const AwardTag ({ award }) => <Tag icon="institution" mainText={award} />
```
The `<Tag>` component will probably need to be modified down the line to accommodate secondary text (e.g `single subject`) depending on the outcome of the design process. Also, the proposed design for the "year in industry"/"year abroad" tag will probably require a bespoke component as it has a different structure to all the other tags.