### PR TITLE
CFIN-305 Improve course search page accessibility

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,6 +1,5 @@
 import {
     FormElement,
-    FormFieldset,
     FormInputText,
     Grid,
     GridBoxFull,
@@ -13,26 +12,24 @@ import PropTypes from "prop-types";
 const Search = ({ searchTerm }) => {
     return (
         <form autoComplete="off" method="get" className="c-form c-form--joined" role="search" aria-label="Courses">
-            <FormFieldset>
-                <Grid>
-                    <GridRow>
-                        <GridBoxFull>
-                            <FormElement>
-                                <FormInputText
-                                    name="search"
-                                    type="text"
-                                    ariaLabel="Search"
-                                    placeholder="Search for your course"
-                                    defaultValue={searchTerm}
-                                />
-                                <button className="c-btn c-btn--medium" type="submit" aria-label="Search">
-                                    <SearchIcon />
-                                </button>
-                            </FormElement>
-                        </GridBoxFull>
-                    </GridRow>
-                </Grid>
-            </FormFieldset>
+            <Grid>
+                <GridRow>
+                    <GridBoxFull>
+                        <FormElement>
+                            <FormInputText
+                                name="search"
+                                type="text"
+                                ariaLabel="Search"
+                                placeholder="Search for your course"
+                                defaultValue={searchTerm}
+                            />
+                            <button className="c-btn c-btn--medium" type="submit" aria-label="Search">
+                                <SearchIcon />
+                            </button>
+                        </FormElement>
+                    </GridBoxFull>
+                </GridRow>
+            </Grid>
         </form>
     );
 };

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,0 +1,22 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+    static async getInitialProps(ctx) {
+        const initialProps = await Document.getInitialProps(ctx);
+        return { ...initialProps };
+    }
+
+    render() {
+        return (
+            <Html lang="en">
+                <Head />
+                <body>
+                    <Main />
+                    <NextScript />
+                </body>
+            </Html>
+        );
+    }
+}
+
+export default MyDocument;


### PR DESCRIPTION
This change covers two accessibility issues flagged by WAVE, if anyone has strong opinions about this I'd welcome any discussion!

- **ERROR: Set a page language** - this is fairly self-explanatory, and is done in a special `pages/_document.js` file which Next understands. I've copied the default page template as shown in [the example in the documentation](https://nextjs.org/docs/advanced-features/custom-document) and just added the `lang` attribute (this specific example is given as a reason to use `_document.js`).

- **ALERT: Fieldset without a legend** - WAVE flagged up that every form fieldset should have a legend; or, if a legend is deemed unnecessary, you probably don't need a fieldset. I read through some of the [accessibility guidelines around creating understandable pages through labels or instructions](https://www.w3.org/WAI/WCAG21/quickref/#labels-or-instructions) (section 3.3.2) which provides a lot of examples of more complex forms that require validation, or information about what the outcome of submitting the form will be (e.g. [one](https://www.w3.org/WAI/WCAG21/Techniques/general/G184.html), [two](https://www.w3.org/WAI/WCAG21/Techniques/general/G89.html), [three](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1.html) etc.). Given the simplicity of the search form, I decided that we probably don't need a legend and therefore don't need to group the form controls under a fieldset.