### PR TITLE
Update GitHub workflow name for npm checks and add shorthand command

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Run XO and Prettier
+name: Run Prettier and XO checks, and tests
 on:
   pull_request:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "checkformat": "prettier --check .",
     "lint": "xo .",
     "check": "npm run checkformat && npm run lint && npm run test",
-    "formatandcheck": "npm run format && npm run lint && npm run test"
+    "formatandcheck": "npm run format && npm run lint && npm run test",
+    "fc": "npm run formatandcheck"
   },
   "dependencies": {
     "@university-of-york/esg-lib-pattern-library-react-components": "^5.0.0",


### PR DESCRIPTION
Two tiny and loosely-related changes, one to update the GitHub workflow's name to be the same as the Courses API workflow, and the other to add a shorthand command that I will find really useful 😃