### PR TITLE
CFIN-327 Display award as part of title

### DIFF
--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -6,7 +6,9 @@ const Course = ({ course }) => {
     return (
         <li className="c-listings-item ">
             <a className="c-listings-item__link" href={course.liveUrl}>
-                <h2 className="c-listings-item__title">{course.title}</h2>
+                <h2 className="c-listings-item__title">
+                    {course.title} {course.award}
+                </h2>
             </a>
             <CourseDetails course={course} />
         </li>

--- a/src/tests/components/Course.test.js
+++ b/src/tests/components/Course.test.js
@@ -2,7 +2,18 @@ import { render, screen } from "@testing-library/react";
 import { Course } from "../../components/Course";
 
 describe("Course", () => {
-    it("displays the course title", () => {
+    it("displays the course title and award", () => {
+        const course = {
+            title: "Mathematics",
+            liveUrl: "",
+            award: "BSc (Hons)",
+        };
+
+        render(<Course course={course} />);
+
+        expect(screen.getByRole("link", { name: "Mathematics BSc (Hons)" })).toBeInTheDocument();
+    });
+    it("displays the course title when no award", () => {
         const course = {
             title: "Mathematics",
             liveUrl: "",


### PR DESCRIPTION
This currently looks a bit like overkill, as the award tag is displaying prominently under the title line. However, if we decide to put the course description in as well, or the tags are less 'in your face', I think it would be helpful. There are many courses with the same title but with both B (3 year) and M (4 year) versions, and be easier to distinguish these in a quick scan of the results if we have the award in the title.

Easy enough to remove later if necessary.