### PR TITLE
CFIN-374 Show a maximum of 20 course search results

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 COURSES_API_BASEURL=https://api.v1.courses.dev.app.york.ac.uk/courses
+COURSES_API_MAX_RESULTS=20

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 COURSES_API_BASEURL=https://api.v1.courses.app.york.ac.uk/courses
+COURSES_API_MAX_RESULTS=20

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,2 @@
 COURSES_API_BASEURL=https://test.courses.api.com
+COURSES_API_MAX_RESULTS=20

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -11,12 +11,12 @@ import {
 import React from "react";
 import PropTypes from "prop-types";
 
-const Search = ({ searchTerm }) => {
+const Search = ({ searchTerm, numberOfMatches, numberOfResultsShown }) => {
     return (
-        <Form action="/" autoComplete="off" method="get" role="search" aria-label="Courses">
-            <Grid>
-                <GridRow>
-                    <GridBoxFull>
+        <Grid>
+            <GridRow>
+                <GridBoxFull>
+                    <Form action="/" autoComplete="off" method="get" role="search" aria-label="Courses">
                         <FormElement>
                             <FormInputText
                                 name="search"
@@ -29,15 +29,41 @@ const Search = ({ searchTerm }) => {
                                 <SearchIcon />
                             </BasicSubmitButton>
                         </FormElement>
-                    </GridBoxFull>
-                </GridRow>
-            </Grid>
-        </Form>
+                    </Form>
+                </GridBoxFull>
+            </GridRow>
+            <GridRow>
+                <GridBoxFull>
+                    <SearchResultsDescription
+                        searchTerm={searchTerm}
+                        numberOfMatches={numberOfMatches}
+                        numberOfResultsShown={numberOfResultsShown}
+                    />
+                </GridBoxFull>
+            </GridRow>
+        </Grid>
     );
 };
 
 Search.propTypes = {
     searchTerm: PropTypes.string,
+    numberOfMatches: PropTypes.number,
+    numberOfResultsShown: PropTypes.number,
+};
+
+const SearchResultsDescription = ({ searchTerm, numberOfMatches, numberOfResultsShown }) => {
+    return (
+        <p data-testid="search-results-description">
+            Showing {numberOfMatches > numberOfResultsShown ? "the top" : "all"} {numberOfResultsShown} results for{" "}
+            <strong>{searchTerm}</strong>
+        </p>
+    );
+};
+
+SearchResultsDescription.propTypes = {
+    searchTerm: PropTypes.string,
+    numberOfMatches: PropTypes.number,
+    numberOfResultsShown: PropTypes.number,
 };
 
 export { Search };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,7 +47,7 @@ App.propTypes = {
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search || "maths";
 
-    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}`;
+    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
 
     let isSuccessfulSearch;
     let searchResponseData;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ import { COURSE_MODEL } from "../constants/CourseModel";
 import { PageHead } from "../components/PageHead";
 import { Search } from "../components/Search";
 
-const App = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
+const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, numberOfResultsShown, searchTerm }) => {
     return (
         <>
             <PageHead search={searchTerm} />
@@ -23,7 +23,11 @@ const App = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
             <WrappedMainGrid>
                 <GridRow>
                     <GridBoxFull>
-                        <Search searchTerm={searchTerm} />
+                        <Search
+                            searchTerm={searchTerm}
+                            numberOfMatches={numberOfMatches}
+                            numberOfResultsShown={numberOfResultsShown}
+                        />
                     </GridBoxFull>
                 </GridRow>
                 <GridRow>
@@ -41,6 +45,8 @@ const App = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
 App.propTypes = {
     isSuccessfulSearch: PropTypes.bool,
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
+    numberOfMatches: PropTypes.number,
+    numberOfResultsShown: PropTypes.number,
     searchTerm: PropTypes.string,
 };
 
@@ -55,13 +61,21 @@ const getServerSideProps = async (context) => {
     try {
         const response = await fetch(courseSearchUrl);
         isSuccessfulSearch = response.ok;
-        searchResponseData = isSuccessfulSearch ? await response.json() : { results: [] };
+        searchResponseData = isSuccessfulSearch ? await response.json() : { numberOfMatches: 0, results: [] };
     } catch {
         isSuccessfulSearch = false;
-        searchResponseData = { results: [] };
+        searchResponseData = { numberOfMatches: 0, results: [] };
     }
 
-    return { props: { isSuccessfulSearch, searchResults: searchResponseData.results, searchTerm } };
+    return {
+        props: {
+            isSuccessfulSearch,
+            searchResults: searchResponseData.results,
+            numberOfMatches: searchResponseData.numberOfMatches,
+            numberOfResultsShown: searchResponseData.results.length,
+            searchTerm,
+        },
+    };
 };
 
 export { App as default, getServerSideProps };

--- a/src/tests/components/Search.test.js
+++ b/src/tests/components/Search.test.js
@@ -22,4 +22,18 @@ describe("Search", () => {
 
         expect(getByRole("textbox", { name: "Search" }).value).toEqual("French");
     });
+
+    it("informs the user that only a limited number of results are being shown when the number of matches is greater than the number of results", () => {
+        render(<Search searchTerm="Maths" numberOfMatches={25} numberOfResultsShown={23} />);
+
+        expect(screen.getByTestId("search-results-description")).toHaveTextContent(
+            "Showing the top 23 results for Maths"
+        );
+    });
+
+    it("informs the user that all results are shown when the number of matches is equal to the number of results", () => {
+        render(<Search searchTerm="Maths" numberOfMatches={5} numberOfResultsShown={5} />);
+
+        expect(screen.getByTestId("search-results-description")).toHaveTextContent("Showing all 5 results for Maths");
+    });
 });

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -82,7 +82,7 @@ describe("getServerSideProps", () => {
         expect(calledUrl).toContain("search=english");
     });
 
-    it("calls the Courses API with a max value", async () => {
+    it("calls the Courses API with a maximum number of results to return", async () => {
         await getServerSideProps(contextWithSearchTerm);
 
         expect(fetch).toHaveBeenCalledTimes(1);

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -6,6 +6,7 @@ beforeEach(() => {
 });
 
 const emptyContext = { query: {} };
+const contextWithSearchTerm = { query: { search: "english" } };
 
 describe("App", () => {
     it("displays an appropriate page heading", () => {
@@ -45,21 +46,49 @@ describe("getServerSideProps", () => {
             })
         );
 
-        const response = await getServerSideProps({ query: { search: "english" } });
+        const response = await getServerSideProps(contextWithSearchTerm);
 
         expect(fetch).toHaveBeenCalledTimes(1);
-        expect(fetch).toHaveBeenCalledWith("https://test.courses.api.com?search=english");
 
         expect(response.props.isSuccessfulSearch).toEqual(true);
         expect(response.props.searchResults).toEqual([{ title: "English" }]);
         expect(response.props.searchTerm).toEqual("english");
     });
 
+    it("calls the Courses API with the correct base url", async () => {
+        await getServerSideProps(emptyContext);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain("https://test.courses.api.com");
+    });
+
     it("calls the Courses API with a default search term when none is entered", async () => {
         await getServerSideProps(emptyContext);
 
         expect(fetch).toHaveBeenCalledTimes(1);
-        expect(fetch).toHaveBeenCalledWith("https://test.courses.api.com?search=maths");
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain("search=maths");
+    });
+
+    it("calls the Courses API with a search term", async () => {
+        await getServerSideProps(contextWithSearchTerm);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain("search=english");
+    });
+
+    it("calls the Courses API with a max value", async () => {
+        await getServerSideProps(contextWithSearchTerm);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain("max=20");
     });
 
     it("indicates when the Courses API search failed (http error response)", async () => {

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -21,6 +21,12 @@ describe("App", () => {
         expect(screen.getByRole("search", { name: "Courses" })).toBeVisible();
     });
 
+    it("displays the search results description", () => {
+        render(<App />);
+
+        expect(screen.getByTestId("search-results-description")).toBeVisible();
+    });
+
     it("displays the titles from course search results", () => {
         const searchResults = [
             { title: "Maths", liveUrl: "http://foo.bar" },
@@ -38,9 +44,13 @@ describe("getServerSideProps", () => {
     it("calls the Courses API and returns response in expected format", async () => {
         fetch.mockResponse(
             JSON.stringify({
+                numberOfMatches: 1,
                 results: [
                     {
                         title: "English",
+                    },
+                    {
+                        title: "Maths",
                     },
                 ],
             })
@@ -51,8 +61,9 @@ describe("getServerSideProps", () => {
         expect(fetch).toHaveBeenCalledTimes(1);
 
         expect(response.props.isSuccessfulSearch).toEqual(true);
-        expect(response.props.searchResults).toEqual([{ title: "English" }]);
+        expect(response.props.searchResults).toEqual([{ title: "English" }, { title: "Maths" }]);
         expect(response.props.searchTerm).toEqual("english");
+        expect(response.props.numberOfResultsShown).toEqual(2);
     });
 
     it("calls the Courses API with the correct base url", async () => {
@@ -97,7 +108,9 @@ describe("getServerSideProps", () => {
         const response = await getServerSideProps(emptyContext);
 
         expect(response.props.isSuccessfulSearch).toEqual(false);
+        expect(response.props.numberOfMatches).toEqual(0);
         expect(response.props.searchResults).toEqual([]);
+        expect(response.props.numberOfResultsShown).toEqual(0);
     });
 
     it("indicates when the Courses API search failed (network or other error)", async () => {
@@ -106,6 +119,23 @@ describe("getServerSideProps", () => {
         const response = await getServerSideProps(emptyContext);
 
         expect(response.props.isSuccessfulSearch).toEqual(false);
+        expect(response.props.numberOfMatches).toEqual(0);
         expect(response.props.searchResults).toEqual([]);
+        expect(response.props.numberOfResultsShown).toEqual(0);
+    });
+
+    it("returns the number of matches from the API", async () => {
+        fetch.mockResponse(
+            JSON.stringify({
+                numberOfMatches: 1,
+                results: [],
+            })
+        );
+
+        const response = await getServerSideProps(contextWithSearchTerm);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(response.props.isSuccessfulSearch).toEqual(true);
+        expect(response.props.numberOfMatches).toEqual(1);
     });
 });


### PR DESCRIPTION
A few tests have been updated to allow us to test different parts of the Courses API url being called. 

There is an option to put COURSES_API_MAX_RESULTS in a single .env file as it's a global value, however we have used the separate files for this PR, has anyone any preferences either way? 