### PR TITLE
CFIN-244 refactor index.js to remove numberOfResultsShown property

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ import { COURSE_MODEL } from "../constants/CourseModel";
 import { PageHead } from "../components/PageHead";
 import { Search } from "../components/Search";
 
-const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, numberOfResultsShown, searchTerm }) => {
+const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, searchTerm }) => {
     return (
         <>
             <PageHead search={searchTerm} />
@@ -26,7 +26,7 @@ const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, numberOfResul
                         <Search
                             searchTerm={searchTerm}
                             numberOfMatches={numberOfMatches}
-                            numberOfResultsShown={numberOfResultsShown}
+                            numberOfResultsShown={searchResults?.length}
                         />
                     </GridBoxFull>
                 </GridRow>
@@ -46,7 +46,6 @@ App.propTypes = {
     isSuccessfulSearch: PropTypes.bool,
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
     numberOfMatches: PropTypes.number,
-    numberOfResultsShown: PropTypes.number,
     searchTerm: PropTypes.string,
 };
 
@@ -72,7 +71,6 @@ const getServerSideProps = async (context) => {
             isSuccessfulSearch,
             searchResults: searchResponseData.results,
             numberOfMatches: searchResponseData.numberOfMatches,
-            numberOfResultsShown: searchResponseData.results.length,
             searchTerm,
         },
     };

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -63,7 +63,6 @@ describe("getServerSideProps", () => {
         expect(response.props.isSuccessfulSearch).toEqual(true);
         expect(response.props.searchResults).toEqual([{ title: "English" }, { title: "Maths" }]);
         expect(response.props.searchTerm).toEqual("english");
-        expect(response.props.numberOfResultsShown).toEqual(2);
     });
 
     it("calls the Courses API with the correct base url", async () => {
@@ -110,7 +109,6 @@ describe("getServerSideProps", () => {
         expect(response.props.isSuccessfulSearch).toEqual(false);
         expect(response.props.numberOfMatches).toEqual(0);
         expect(response.props.searchResults).toEqual([]);
-        expect(response.props.numberOfResultsShown).toEqual(0);
     });
 
     it("indicates when the Courses API search failed (network or other error)", async () => {
@@ -121,7 +119,6 @@ describe("getServerSideProps", () => {
         expect(response.props.isSuccessfulSearch).toEqual(false);
         expect(response.props.numberOfMatches).toEqual(0);
         expect(response.props.searchResults).toEqual([]);
-        expect(response.props.numberOfResultsShown).toEqual(0);
     });
 
     it("returns the number of matches from the API", async () => {


### PR DESCRIPTION
This is a small change based on @FergusMcGlynn 's suggestion to remove the `numberOfResultsShown` property from `index.js`