### PR TITLE
Submit Course Search form requests to the index page rather than the top level of the domain

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -16,7 +16,7 @@ const Search = ({ searchTerm, numberOfMatches, numberOfResultsShown }) => {
         <Grid>
             <GridRow>
                 <GridBoxFull>
-                    <Form action="/" autoComplete="off" method="get" role="search" aria-label="Courses">
+                    <Form action="" autoComplete="off" method="get" role="search" aria-label="Courses">
                         <FormElement>
                             <FormInputText
                                 name="search"


### PR DESCRIPTION
This means that the application will work when accessed through AWS API gateway.

This is an issue that cropped up when testing CFIN-244, where we saw the search form didn't work when deployed to an AWS sandbox account due to the `/v1/` in the path of the API gateway URL - in this case it's a tiny fix to make the form work.