### PR TITLE
Exclude "sharp" dependency from deployment bundle

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -73,6 +73,7 @@ package:
     - node_modules/ext/**
     - node_modules/tr46/**
     - node_modules/micromatch/**
+    - node_modules/sharp/**
 
 resources:
   Conditions:


### PR DESCRIPTION
Next.js v10 adds "[sharp](https://github.com/lovell/sharp)" (an image processing module) as a dependency. It is > 50 MB in size uncompressed, and was bloating our deployment bundle from ~15 MB to ~38 MB (compressed). The deployment bundle size negatively affects the Lambda's (and therefore Course Search's) performance. Sharp isn't needed at runtime (I'm fairly sure) so it can be excluded from the deployment bundle. I have deployed this version to my sandbox and verified that the app behaves as it should.