### PR TITLE
Add workflow to check the package size

### DIFF
--- a/.github/workflows/application-size.yml
+++ b/.github/workflows/application-size.yml
@@ -1,0 +1,31 @@
+name: Application Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the application's source code
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com
+          scope: "@university-of-york"
+          always-auth: true
+
+      - name: Check the application's file size
+        uses: preactjs/compressed-size-action@e2bfc4b346d78f9a3c7e8a2e22bcbd285a25fafa
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          build-script: package
+          pattern: .serverless/*.zip
+          compression: none
+          minimum-change-threshold: 1024
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          AWS_ACCOUNT_ID: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+

--- a/.github/workflows/report-package-size.yml
+++ b/.github/workflows/report-package-size.yml
@@ -26,5 +26,5 @@ jobs:
           compression: none
           minimum-change-threshold: 1024
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           AWS_ACCOUNT_ID: ${{ secrets.DEV_AWS_ACCOUNT_ID }}

--- a/.github/workflows/report-package-size.yml
+++ b/.github/workflows/report-package-size.yml
@@ -1,4 +1,4 @@
-name: Application Size
+name: Report Package Size
 
 on: [pull_request]
 
@@ -17,7 +17,7 @@ jobs:
           scope: "@university-of-york"
           always-auth: true
 
-      - name: Check the application's file size
+      - name: Check and report changes in the application's package size
         uses: preactjs/compressed-size-action@e2bfc4b346d78f9a3c7e8a2e22bcbd285a25fafa
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-package-size.yml
+++ b/.github/workflows/report-package-size.yml
@@ -28,4 +28,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           AWS_ACCOUNT_ID: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
-

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "package": "next build && sls package",
     "deploy": "next build && sls deploy --env production",
     "deploy:dev": "next build && sls deploy --env development",
     "undeploy": "sls remove",


### PR DESCRIPTION
This PR is a suggestion, so thoughts would be very welcome! :thought_balloon: 

Inspired by #65 where I upgraded the application to Next 10 which unwittingly increased the package size, and #69 from Ferg which excluded the relevant dependency to shrink it back down, I thought it might be a good idea to get more visibility of our package size. This PR adds a workflow that uses the [compressed-size-action](https://github.com/marketplace/actions/compressed-size-action) (from the maintainers of preactjs) to do exactly that.

I recreated the above PRs in a demo repo to see what it'd look like, you can check them out [here](https://github.com/university-of-york/ce666-demo-repo/pull/6) and [here](https://github.com/university-of-york/ce666-demo-repo/pull/7) (and [here](https://github.com/university-of-york/ce666-demo-repo/pull/8) for one that shows minimal changes).

One thing to consider is that email notifications are sent for comments (unless you turn them off in your notification settings).

**Note**: The check doesn't run successfully in this PR because the action works by comparing the current branch against the target branch, and the `package` command that I'm using here doesn't yet exist in the target branch.