### PR TITLE
CFIN-384: Show no search results when no search terms entered

### DIFF
--- a/src/components/CourseSearchResults.js
+++ b/src/components/CourseSearchResults.js
@@ -4,7 +4,11 @@ import { COURSE_MODEL } from "../constants/CourseModel";
 import React from "react";
 import { Alert } from "@university-of-york/esg-lib-pattern-library-react-components";
 
-const CourseSearchResults = ({ isSuccessfulSearch, searchResults }) => {
+const CourseSearchResults = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
+    if (!searchTerm) {
+        return null;
+    }
+
     if (!isSuccessfulSearch) {
         return <SearchFailedMessage />;
     }
@@ -25,6 +29,7 @@ const CourseSearchResults = ({ isSuccessfulSearch, searchResults }) => {
 CourseSearchResults.propTypes = {
     isSuccessfulSearch: PropTypes.bool,
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
+    searchTerm: PropTypes.string,
 };
 
 const SearchFailedMessage = () => (

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -52,6 +52,10 @@ Search.propTypes = {
 };
 
 const SearchResultsDescription = ({ searchTerm, numberOfMatches, numberOfResultsShown }) => {
+    if (!searchTerm) {
+        return null;
+    }
+
     return (
         <p data-testid="search-results-description">
             Showing {numberOfMatches > numberOfResultsShown ? "the top" : "all"} {numberOfResultsShown} results for{" "}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,7 +32,11 @@ const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, searchTerm })
                 </GridRow>
                 <GridRow>
                     <GridBoxFull>
-                        <CourseSearchResults isSuccessfulSearch={isSuccessfulSearch} searchResults={searchResults} />
+                        <CourseSearchResults
+                            isSuccessfulSearch={isSuccessfulSearch}
+                            searchResults={searchResults}
+                            searchTerm={searchTerm}
+                        />
                     </GridBoxFull>
                 </GridRow>
             </WrappedMainGrid>
@@ -50,7 +54,11 @@ App.propTypes = {
 };
 
 const getServerSideProps = async (context) => {
-    const searchTerm = context.query.search || "maths";
+    const searchTerm = context.query.search;
+
+    if (!searchTerm) {
+        return { props: {} };
+    }
 
     const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
 

--- a/src/tests/components/CourseSearchResults.test.js
+++ b/src/tests/components/CourseSearchResults.test.js
@@ -8,14 +8,14 @@ describe("CourseSearchResults", () => {
             { title: "Physics", liveUrl: "http://foo.baz" },
         ];
 
-        render(<CourseSearchResults isSuccessfulSearch searchResults={searchResults} />);
+        render(<CourseSearchResults isSuccessfulSearch searchResults={searchResults} searchTerm="foobar" />);
 
         expect(screen.getByRole("link", { name: "Maths" })).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "Physics" })).toBeInTheDocument();
     });
 
     it("displays an appropriate message when the course search failed", () => {
-        render(<CourseSearchResults isSuccessfulSearch={false} />);
+        render(<CourseSearchResults isSuccessfulSearch={false} searchTerm="foobar" />);
 
         expect(screen.getByText(/Course search is currently unavailable. Please try again later/)).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "contact IT Support" })).toBeInTheDocument();
@@ -26,8 +26,19 @@ describe("CourseSearchResults", () => {
     });
 
     it("displays an appropriate message when there are no search results returned", () => {
-        render(<CourseSearchResults isSuccessfulSearch searchResults={[]} />);
+        render(<CourseSearchResults isSuccessfulSearch searchResults={[]} searchTerm="foobar" />);
 
         expect(screen.getByText(/Sorry, your search did not return any results/)).toBeVisible();
+    });
+
+    it.each`
+        description    | searchTerm
+        ${"blank"}     | ${""}
+        ${"null"}      | ${null}
+        ${"undefined"} | ${undefined}
+    `("displays nothing when user has entered $description search terms", ({ searchTerm }) => {
+        render(<CourseSearchResults searchTerm={searchTerm} />);
+
+        expect(screen.queryByText(/./)).not.toBeInTheDocument();
     });
 });

--- a/src/tests/components/Search.test.js
+++ b/src/tests/components/Search.test.js
@@ -36,4 +36,15 @@ describe("Search", () => {
 
         expect(screen.getByTestId("search-results-description")).toHaveTextContent("Showing all 5 results for Maths");
     });
+
+    it.each`
+        description    | searchTerm
+        ${"blank"}     | ${""}
+        ${"null"}      | ${null}
+        ${"undefined"} | ${undefined}
+    `("does not display any text when given $description search terms", ({ searchTerm }) => {
+        render(<Search searchTerm={searchTerm} />);
+
+        expect(screen.queryByText(/./)).not.toBeInTheDocument();
+    });
 });

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -22,7 +22,7 @@ describe("App", () => {
     });
 
     it("displays the search results description", () => {
-        render(<App />);
+        render(<App searchTerm="foobar" />);
 
         expect(screen.getByTestId("search-results-description")).toBeVisible();
     });

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -33,7 +33,7 @@ describe("App", () => {
             { title: "Physics", liveUrl: "http://foo.baz" },
         ];
 
-        render(<App isSuccessfulSearch searchResults={searchResults} />);
+        render(<App isSuccessfulSearch searchResults={searchResults} searchTerm="foobar" />);
 
         expect(screen.getByRole("link", { name: "Maths" })).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "Physics" })).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe("getServerSideProps", () => {
     });
 
     it("constructs the Courses API url with the expected environment variables", async () => {
-        await getServerSideProps(emptyContext);
+        await getServerSideProps(contextWithSearchTerm);
 
         expect(fetch).toHaveBeenCalledTimes(1);
 
@@ -76,7 +76,7 @@ describe("getServerSideProps", () => {
     });
 
     it("calls the Courses API with the correct base url", async () => {
-        await getServerSideProps(emptyContext);
+        await getServerSideProps(contextWithSearchTerm);
 
         expect(fetch).toHaveBeenCalledTimes(1);
 
@@ -84,13 +84,10 @@ describe("getServerSideProps", () => {
         expect(calledUrl).toContain(process.env.COURSES_API_BASEURL);
     });
 
-    it("calls the Courses API with a default search term when none is entered", async () => {
+    it("does not call the Courses API when no search term is entered", async () => {
         await getServerSideProps(emptyContext);
 
-        expect(fetch).toHaveBeenCalledTimes(1);
-
-        const calledUrl = fetch.mock.calls[0][0];
-        expect(calledUrl).toContain("search=maths");
+        expect(fetch).toHaveBeenCalledTimes(0);
     });
 
     it("calls the Courses API with a search term", async () => {
@@ -114,7 +111,7 @@ describe("getServerSideProps", () => {
     it("indicates when the Courses API search failed (http error response)", async () => {
         fetch.mockResponse("{}", { status: 500 });
 
-        const response = await getServerSideProps(emptyContext);
+        const response = await getServerSideProps(contextWithSearchTerm);
 
         expect(response.props.isSuccessfulSearch).toEqual(false);
         expect(response.props.numberOfMatches).toEqual(0);
@@ -124,7 +121,7 @@ describe("getServerSideProps", () => {
     it("indicates when the Courses API search failed (network or other error)", async () => {
         fetch.mockReject(new Error("can not resolve host"));
 
-        const response = await getServerSideProps(emptyContext);
+        const response = await getServerSideProps(contextWithSearchTerm);
 
         expect(response.props.isSuccessfulSearch).toEqual(false);
         expect(response.props.numberOfMatches).toEqual(0);
@@ -144,5 +141,11 @@ describe("getServerSideProps", () => {
         expect(fetch).toHaveBeenCalledTimes(1);
         expect(response.props.isSuccessfulSearch).toEqual(true);
         expect(response.props.numberOfMatches).toEqual(1);
+    });
+
+    it("returns nothing when given no search terms", async () => {
+        const response = await getServerSideProps(emptyContext);
+
+        expect(response.props).toEqual({});
     });
 });


### PR DESCRIPTION
This PR includes changes to ensure that no search results, and no search description text (e.g. "showing top n results"), are presented when there are no search terms. A future PR will add functionality to display a message to the user stating that they didn't enter any search terms.

[Try it out in my sandbox](https://courses.ferg.dev.app.york.ac.uk/)