### PR TITLE
CFIN-383: Show "no results" message to user when they enter no search terms

### DIFF
--- a/src/components/CourseSearchResults.js
+++ b/src/components/CourseSearchResults.js
@@ -5,7 +5,7 @@ import React from "react";
 import { Alert } from "@university-of-york/esg-lib-pattern-library-react-components";
 
 const CourseSearchResults = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
-    if (!searchTerm) {
+    if (searchTerm === null || searchTerm === undefined) {
         return null;
     }
 

--- a/src/components/CourseSearchResults.js
+++ b/src/components/CourseSearchResults.js
@@ -3,9 +3,10 @@ import PropTypes from "prop-types";
 import { COURSE_MODEL } from "../constants/CourseModel";
 import React from "react";
 import { Alert } from "@university-of-york/esg-lib-pattern-library-react-components";
+import { noSearchConducted } from "../utils/searchTerms";
 
 const CourseSearchResults = ({ isSuccessfulSearch, searchResults, searchTerm }) => {
-    if (searchTerm === null || searchTerm === undefined) {
+    if (noSearchConducted(searchTerm)) {
         return null;
     }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,6 +12,7 @@ import { CourseSearchResults } from "../components/CourseSearchResults";
 import { COURSE_MODEL } from "../constants/CourseModel";
 import { PageHead } from "../components/PageHead";
 import { Search } from "../components/Search";
+import { emptySearchConducted, noSearchConducted } from "../utils/searchTerms";
 
 const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, searchTerm }) => {
     return (
@@ -56,11 +57,11 @@ App.propTypes = {
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search;
 
-    if (searchTerm === null || searchTerm === undefined) {
+    if (noSearchConducted(searchTerm)) {
         return { props: {} };
     }
 
-    if (searchTerm === "") {
+    if (emptySearchConducted(searchTerm)) {
         return { props: { searchTerm, isSuccessfulSearch: true, searchResults: [], numberOfMatches: 0 } };
     }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,8 +56,12 @@ App.propTypes = {
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search;
 
-    if (!searchTerm) {
+    if (searchTerm === null || searchTerm === undefined) {
         return { props: {} };
+    }
+
+    if (searchTerm === "") {
+        return { props: { searchTerm, isSuccessfulSearch: true, searchResults: [], numberOfMatches: 0 } };
     }
 
     const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;

--- a/src/tests/components/CourseSearchResults.test.js
+++ b/src/tests/components/CourseSearchResults.test.js
@@ -15,7 +15,7 @@ describe("CourseSearchResults", () => {
     });
 
     it("displays an appropriate message when the course search failed", () => {
-        render(<CourseSearchResults isSuccessfulSearch={false} searchTerm="foobar" />);
+        render(<CourseSearchResults isSuccessfulSearch={false} searchResults={[]} searchTerm="foobar" />);
 
         expect(screen.getByText(/Course search is currently unavailable. Please try again later/)).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "contact IT Support" })).toBeInTheDocument();

--- a/src/tests/components/CourseSearchResults.test.js
+++ b/src/tests/components/CourseSearchResults.test.js
@@ -25,18 +25,21 @@ describe("CourseSearchResults", () => {
         );
     });
 
-    it("displays an appropriate message when there are no search results returned", () => {
-        render(<CourseSearchResults isSuccessfulSearch searchResults={[]} searchTerm="foobar" />);
+    it.each`
+        description    | searchTerm
+        ${"empty"}     | ${""}
+        ${"non-empty"} | ${"foobar"}
+    `("displays appropriate message when no search results returned ($description search term)", ({ searchTerm }) => {
+        render(<CourseSearchResults isSuccessfulSearch searchResults={[]} searchTerm={searchTerm} />);
 
         expect(screen.getByText(/Sorry, your search did not return any results/)).toBeVisible();
     });
 
     it.each`
         description    | searchTerm
-        ${"blank"}     | ${""}
         ${"null"}      | ${null}
         ${"undefined"} | ${undefined}
-    `("displays nothing when user has entered $description search terms", ({ searchTerm }) => {
+    `("displays nothing when search terms are $description (e.g. on initial visit)", ({ searchTerm }) => {
         render(<CourseSearchResults searchTerm={searchTerm} />);
 
         expect(screen.queryByText(/./)).not.toBeInTheDocument();

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -143,9 +143,22 @@ describe("getServerSideProps", () => {
         expect(response.props.numberOfMatches).toEqual(1);
     });
 
-    it("returns nothing when given no search terms", async () => {
-        const response = await getServerSideProps(emptyContext);
+    it.each`
+        description    | searchTerm
+        ${"null"}      | ${null}
+        ${"undefined"} | ${undefined}
+    `("returns nothing when given $description search terms (e.g. on initial visit)", async ({ searchTerm }) => {
+        const response = await getServerSideProps({ query: { search: searchTerm } });
 
         expect(response.props).toEqual({});
+    });
+
+    it("returns blank properties when user conducts blank search", async () => {
+        const response = await getServerSideProps({ query: { search: "" } });
+
+        expect(response.props.searchTerm).toEqual("");
+        expect(response.props.isSuccessfulSearch).toEqual(true);
+        expect(response.props.searchResults).toEqual([]);
+        expect(response.props.numberOfMatches).toEqual(0);
     });
 });

--- a/src/tests/utils/searchTerms.test.js
+++ b/src/tests/utils/searchTerms.test.js
@@ -1,0 +1,34 @@
+import { noSearchConducted, emptySearchConducted } from "../../utils/searchTerms";
+
+describe("noSearchConducted", () => {
+    it.each`
+        description    | searchTerm
+        ${"null"}      | ${null}
+        ${"undefined"} | ${undefined}
+    `("returns true when search terms are $description", ({ searchTerm }) => {
+        expect(noSearchConducted(searchTerm)).toBe(true);
+    });
+
+    it.each`
+        description    | searchTerm
+        ${"empty"}     | ${""}
+        ${"non-empty"} | ${"foobar"}
+    `("returns false when search terms are $description", ({ searchTerm }) => {
+        expect(noSearchConducted(searchTerm)).toBe(false);
+    });
+});
+
+describe("emptySearchConducted", () => {
+    it("returns true when search terms are empty", () => {
+        expect(emptySearchConducted("")).toBe(true);
+    });
+
+    it.each`
+        description    | searchTerm
+        ${"null"}      | ${null}
+        ${"undefined"} | ${undefined}
+        ${"non-empty"} | ${"foobar"}
+    `("returns false when search terms are $description", ({ searchTerm }) => {
+        expect(emptySearchConducted(searchTerm)).toBe(false);
+    });
+});

--- a/src/utils/searchTerms.js
+++ b/src/utils/searchTerms.js
@@ -1,0 +1,9 @@
+const noSearchConducted = (searchTerm) => {
+    return searchTerm === null || searchTerm === undefined;
+};
+
+const emptySearchConducted = (searchTerm) => {
+    return searchTerm === "";
+};
+
+export { noSearchConducted, emptySearchConducted };


### PR DESCRIPTION
This solution relies on discriminating between `searchTerm === undefined` (meaning no search has been conducted yet) and `searchTerm === ""` (meaning an empty search has been conducted). I thought that was a bit of a subtle distinction so I've introduced a couple of helper functions to make these scenarios explicit.

[Try it out in my sandbox](https://courses.ferg.dev.app.york.ac.uk/)