### PR TITLE
CFIN-393: Omit "showing 0 results" when no search results

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -52,7 +52,7 @@ Search.propTypes = {
 };
 
 const SearchResultsDescription = ({ searchTerm, numberOfMatches, numberOfResultsShown }) => {
-    if (!searchTerm) {
+    if (!numberOfResultsShown) {
         return null;
     }
 

--- a/src/tests/components/Search.test.js
+++ b/src/tests/components/Search.test.js
@@ -37,13 +37,8 @@ describe("Search", () => {
         expect(screen.getByTestId("search-results-description")).toHaveTextContent("Showing all 5 results for Maths");
     });
 
-    it.each`
-        description    | searchTerm
-        ${"blank"}     | ${""}
-        ${"null"}      | ${null}
-        ${"undefined"} | ${undefined}
-    `("does not display any text when given $description search terms", ({ searchTerm }) => {
-        render(<Search searchTerm={searchTerm} />);
+    it("does not display any text when there are no search results", () => {
+        render(<Search numberOfResultsShown={0} />);
 
         expect(screen.queryByText(/./)).not.toBeInTheDocument();
     });

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -5,6 +5,10 @@ beforeEach(() => {
     fetch.resetMocks();
 });
 
+const searchResults = [
+    { title: "Maths", liveUrl: "http://foo.bar" },
+    { title: "Physics", liveUrl: "http://foo.baz" },
+];
 const emptyContext = { query: {} };
 const contextWithSearchTerm = { query: { search: "english" } };
 
@@ -22,17 +26,12 @@ describe("App", () => {
     });
 
     it("displays the search results description", () => {
-        render(<App searchTerm="foobar" />);
+        render(<App isSuccessfulSearch searchResults={searchResults} searchTerm="foobar" />);
 
         expect(screen.getByTestId("search-results-description")).toBeVisible();
     });
 
     it("displays the titles from course search results", () => {
-        const searchResults = [
-            { title: "Maths", liveUrl: "http://foo.bar" },
-            { title: "Physics", liveUrl: "http://foo.baz" },
-        ];
-
         render(<App isSuccessfulSearch searchResults={searchResults} searchTerm="foobar" />);
 
         expect(screen.getByRole("link", { name: "Maths" })).toBeInTheDocument();


### PR DESCRIPTION
When there are no search results, up til now, we have been presenting a message stating "Showing 0 results for <search term>" and also showing a message saying "Sorry, there were no results for this search". This PR removes the first message in this situation.