### PR TITLE
CFIN-412: Refactor option 1 - extract Courses API search into separate function

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,25 +54,6 @@ App.propTypes = {
     searchTerm: PropTypes.string,
 };
 
-const searchForCourses = async (searchTerm) => {
-    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
-
-    let isSuccessfulSearch;
-    let searchResponseData;
-    const defaultResponse = { numberOfMatches: 0, results: [] };
-
-    try {
-        const response = await fetch(courseSearchUrl);
-        isSuccessfulSearch = response.ok;
-        searchResponseData = isSuccessfulSearch ? await response.json() : defaultResponse;
-    } catch {
-        isSuccessfulSearch = false;
-        searchResponseData = defaultResponse;
-    }
-
-    return { isSuccessfulSearch, searchResponseData };
-};
-
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search;
 
@@ -94,6 +75,25 @@ const getServerSideProps = async (context) => {
             numberOfMatches: searchResponseData.numberOfMatches,
         },
     };
+};
+
+const searchForCourses = async (searchTerm) => {
+    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
+
+    let isSuccessfulSearch;
+    let searchResponseData;
+    const defaultResponse = { numberOfMatches: 0, results: [] };
+
+    try {
+        const response = await fetch(courseSearchUrl);
+        isSuccessfulSearch = response.ok;
+        searchResponseData = isSuccessfulSearch ? await response.json() : defaultResponse;
+    } catch {
+        isSuccessfulSearch = false;
+        searchResponseData = defaultResponse;
+    }
+
+    return { isSuccessfulSearch, searchResponseData };
 };
 
 export { App as default, getServerSideProps };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,6 +54,25 @@ App.propTypes = {
     searchTerm: PropTypes.string,
 };
 
+const searchForCourses = async (searchTerm) => {
+    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
+
+    let isSuccessfulSearch;
+    let searchResponseData;
+    const defaultResponse = { numberOfMatches: 0, results: [] };
+
+    try {
+        const response = await fetch(courseSearchUrl);
+        isSuccessfulSearch = response.ok;
+        searchResponseData = isSuccessfulSearch ? await response.json() : defaultResponse;
+    } catch {
+        isSuccessfulSearch = false;
+        searchResponseData = defaultResponse;
+    }
+
+    return { isSuccessfulSearch, searchResponseData };
+};
+
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search;
 
@@ -65,26 +84,14 @@ const getServerSideProps = async (context) => {
         return { props: { searchTerm, isSuccessfulSearch: true, searchResults: [], numberOfMatches: 0 } };
     }
 
-    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
-
-    let isSuccessfulSearch;
-    let searchResponseData;
-
-    try {
-        const response = await fetch(courseSearchUrl);
-        isSuccessfulSearch = response.ok;
-        searchResponseData = isSuccessfulSearch ? await response.json() : { numberOfMatches: 0, results: [] };
-    } catch {
-        isSuccessfulSearch = false;
-        searchResponseData = { numberOfMatches: 0, results: [] };
-    }
+    const { isSuccessfulSearch, searchResponseData } = await searchForCourses(searchTerm);
 
     return {
         props: {
+            searchTerm,
             isSuccessfulSearch,
             searchResults: searchResponseData.results,
             numberOfMatches: searchResponseData.numberOfMatches,
-            searchTerm,
         },
     };
 };


### PR DESCRIPTION
This is the first of 2 alternative options for a refactor.

This one extracts the block of code that handles calling the Courses API  out of `getServerSideProps` and into its own private function in the same file. It's a fairly minimal change.

Do you prefer one or the other? Or neither?