### PR TITLE
CFIN-412: Refactor option 2 - move Courses API search to new module

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,6 +54,25 @@ App.propTypes = {
     searchTerm: PropTypes.string,
 };
 
+const searchForCourses = async (searchTerm) => {
+    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
+
+    let isSuccessfulSearch;
+    let searchResponseData;
+    const defaultResponse = { numberOfMatches: 0, results: [] };
+
+    try {
+        const response = await fetch(courseSearchUrl);
+        isSuccessfulSearch = response.ok;
+        searchResponseData = isSuccessfulSearch ? await response.json() : defaultResponse;
+    } catch {
+        isSuccessfulSearch = false;
+        searchResponseData = defaultResponse;
+    }
+
+    return { isSuccessfulSearch, searchResponseData };
+};
+
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search;
 
@@ -65,26 +84,14 @@ const getServerSideProps = async (context) => {
         return { props: { searchTerm, isSuccessfulSearch: true, searchResults: [], numberOfMatches: 0 } };
     }
 
-    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
-
-    let isSuccessfulSearch;
-    let searchResponseData;
-
-    try {
-        const response = await fetch(courseSearchUrl);
-        isSuccessfulSearch = response.ok;
-        searchResponseData = isSuccessfulSearch ? await response.json() : { numberOfMatches: 0, results: [] };
-    } catch {
-        isSuccessfulSearch = false;
-        searchResponseData = { numberOfMatches: 0, results: [] };
-    }
+    const { isSuccessfulSearch, searchResponseData } = await searchForCourses(searchTerm);
 
     return {
         props: {
+            searchTerm,
             isSuccessfulSearch,
             searchResults: searchResponseData.results,
             numberOfMatches: searchResponseData.numberOfMatches,
-            searchTerm,
         },
     };
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,6 +13,7 @@ import { COURSE_MODEL } from "../constants/CourseModel";
 import { PageHead } from "../components/PageHead";
 import { Search } from "../components/Search";
 import { emptySearchConducted, noSearchConducted } from "../utils/searchTerms";
+import { searchForCourses } from "../utils/searchForCourses";
 
 const App = ({ isSuccessfulSearch, searchResults, numberOfMatches, searchTerm }) => {
     return (
@@ -52,25 +53,6 @@ App.propTypes = {
     searchResults: PropTypes.arrayOf(COURSE_MODEL),
     numberOfMatches: PropTypes.number,
     searchTerm: PropTypes.string,
-};
-
-const searchForCourses = async (searchTerm) => {
-    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
-
-    let isSuccessfulSearch;
-    let searchResponseData;
-    const defaultResponse = { numberOfMatches: 0, results: [] };
-
-    try {
-        const response = await fetch(courseSearchUrl);
-        isSuccessfulSearch = response.ok;
-        searchResponseData = isSuccessfulSearch ? await response.json() : defaultResponse;
-    } catch {
-        isSuccessfulSearch = false;
-        searchResponseData = defaultResponse;
-    }
-
-    return { isSuccessfulSearch, searchResponseData };
 };
 
 const getServerSideProps = async (context) => {

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -1,8 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import App, { getServerSideProps } from "../../pages";
+import { searchForCourses } from "../../utils/searchForCourses";
+
+jest.mock("../../utils/searchForCourses");
 
 beforeEach(() => {
-    fetch.resetMocks();
+    jest.clearAllMocks();
 });
 
 const emptyContext = { query: {} };
@@ -41,75 +44,44 @@ describe("App", () => {
 });
 
 describe("getServerSideProps", () => {
-    it("calls the Courses API and returns response in expected format", async () => {
-        fetch.mockResponse(
-            JSON.stringify({
-                numberOfMatches: 1,
-                results: [
-                    {
-                        title: "English",
-                    },
-                    {
-                        title: "Maths",
-                    },
-                ],
-            })
-        );
+    it("calls course search and returns response in expected format", async () => {
+        searchForCourses.mockResolvedValue({
+            isSuccessfulSearch: true,
+            searchResponseData: { numberOfMatches: 1, results: [{ title: "English" }, { title: "Maths" }] },
+        });
 
         const response = await getServerSideProps(contextWithSearchTerm);
 
-        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(searchForCourses).toHaveBeenCalledTimes(1);
 
         expect(response.props.isSuccessfulSearch).toEqual(true);
         expect(response.props.searchResults).toEqual([{ title: "English" }, { title: "Maths" }]);
         expect(response.props.searchTerm).toEqual("english");
     });
 
-    it("constructs the Courses API url with the expected environment variables", async () => {
-        await getServerSideProps(contextWithSearchTerm);
-
-        expect(fetch).toHaveBeenCalledTimes(1);
-
-        const calledUrl = fetch.mock.calls[0][0];
-        expect(calledUrl).toContain("https://test.courses.api.com");
-        expect(calledUrl).toContain("max=20");
-    });
-
-    it("calls the Courses API with the correct base url", async () => {
-        await getServerSideProps(contextWithSearchTerm);
-
-        expect(fetch).toHaveBeenCalledTimes(1);
-
-        const calledUrl = fetch.mock.calls[0][0];
-        expect(calledUrl).toContain(process.env.COURSES_API_BASEURL);
-    });
-
-    it("does not call the Courses API when no search term is entered", async () => {
+    it("does not search for courses when no search term is entered", async () => {
         await getServerSideProps(emptyContext);
 
-        expect(fetch).toHaveBeenCalledTimes(0);
+        expect(searchForCourses).toHaveBeenCalledTimes(0);
     });
 
-    it("calls the Courses API with a search term", async () => {
+    it("calls course search with a search term", async () => {
+        searchForCourses.mockResolvedValue({
+            isSuccessfulSearch: true,
+            searchResponseData: { numberOfMatches: 0, results: [] },
+        });
+
         await getServerSideProps(contextWithSearchTerm);
 
-        expect(fetch).toHaveBeenCalledTimes(1);
-
-        const calledUrl = fetch.mock.calls[0][0];
-        expect(calledUrl).toContain("search=english");
+        expect(searchForCourses).toHaveBeenCalledTimes(1);
+        expect(searchForCourses).toHaveBeenCalledWith("english");
     });
 
-    it("calls the Courses API with a maximum number of results to return", async () => {
-        await getServerSideProps(contextWithSearchTerm);
-
-        expect(fetch).toHaveBeenCalledTimes(1);
-
-        const calledUrl = fetch.mock.calls[0][0];
-        expect(calledUrl).toContain(`max=${process.env.COURSES_API_MAX_RESULTS}`);
-    });
-
-    it("indicates when the Courses API search failed (http error response)", async () => {
-        fetch.mockResponse("{}", { status: 500 });
+    it("indicates when the course search failed", async () => {
+        searchForCourses.mockResolvedValue({
+            isSuccessfulSearch: false,
+            searchResponseData: { numberOfMatches: 0, results: [] },
+        });
 
         const response = await getServerSideProps(contextWithSearchTerm);
 
@@ -118,27 +90,16 @@ describe("getServerSideProps", () => {
         expect(response.props.searchResults).toEqual([]);
     });
 
-    it("indicates when the Courses API search failed (network or other error)", async () => {
-        fetch.mockReject(new Error("can not resolve host"));
+    it("returns the number of matches from the course search", async () => {
+        searchForCourses.mockResolvedValue({
+            isSuccessfulSearch: true,
+            searchResponseData: { numberOfMatches: 1, results: [] },
+        });
 
         const response = await getServerSideProps(contextWithSearchTerm);
 
-        expect(response.props.isSuccessfulSearch).toEqual(false);
-        expect(response.props.numberOfMatches).toEqual(0);
-        expect(response.props.searchResults).toEqual([]);
-    });
+        expect(searchForCourses).toHaveBeenCalledTimes(1);
 
-    it("returns the number of matches from the API", async () => {
-        fetch.mockResponse(
-            JSON.stringify({
-                numberOfMatches: 1,
-                results: [],
-            })
-        );
-
-        const response = await getServerSideProps(contextWithSearchTerm);
-
-        expect(fetch).toHaveBeenCalledTimes(1);
         expect(response.props.isSuccessfulSearch).toEqual(true);
         expect(response.props.numberOfMatches).toEqual(1);
     });

--- a/src/tests/utils/searchForCourses.test.js
+++ b/src/tests/utils/searchForCourses.test.js
@@ -1,0 +1,102 @@
+import { searchForCourses } from "../../utils/searchForCourses";
+
+beforeEach(() => {
+    fetch.resetMocks();
+});
+
+describe("searchForCourses", () => {
+    it("calls the Courses API and returns response in expected format", async () => {
+        fetch.mockResponse(
+            JSON.stringify({
+                numberOfMatches: 1,
+                results: [
+                    {
+                        title: "English",
+                    },
+                    {
+                        title: "Maths",
+                    },
+                ],
+            })
+        );
+
+        const { isSuccessfulSearch, searchResponseData } = await searchForCourses("english");
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        expect(isSuccessfulSearch).toEqual(true);
+        expect(searchResponseData.results).toEqual([{ title: "English" }, { title: "Maths" }]);
+    });
+
+    it("constructs the Courses API url with the expected environment variables", async () => {
+        await searchForCourses("english");
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain("https://test.courses.api.com");
+        expect(calledUrl).toContain("max=20");
+    });
+
+    it("calls the Courses API with the correct base url", async () => {
+        await searchForCourses("english");
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain(process.env.COURSES_API_BASEURL);
+    });
+
+    it("calls the Courses API with a search term", async () => {
+        await searchForCourses("english");
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain("search=english");
+    });
+
+    it("calls the Courses API with a maximum number of results to return", async () => {
+        await searchForCourses("english");
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const calledUrl = fetch.mock.calls[0][0];
+        expect(calledUrl).toContain(`max=${process.env.COURSES_API_MAX_RESULTS}`);
+    });
+
+    it("indicates when the Courses API search failed (http error response)", async () => {
+        fetch.mockResponse("{}", { status: 500 });
+
+        const { isSuccessfulSearch, searchResponseData } = await searchForCourses("english");
+
+        expect(isSuccessfulSearch).toEqual(false);
+        expect(searchResponseData.numberOfMatches).toEqual(0);
+        expect(searchResponseData.results).toEqual([]);
+    });
+
+    it("indicates when the Courses API search failed (network or other error)", async () => {
+        fetch.mockReject(new Error("can not resolve host"));
+
+        const { isSuccessfulSearch, searchResponseData } = await searchForCourses("english");
+
+        expect(isSuccessfulSearch).toEqual(false);
+        expect(searchResponseData.numberOfMatches).toEqual(0);
+        expect(searchResponseData.results).toEqual([]);
+    });
+
+    it("returns the number of matches from the API", async () => {
+        fetch.mockResponse(
+            JSON.stringify({
+                numberOfMatches: 1,
+                results: [],
+            })
+        );
+
+        const { isSuccessfulSearch, searchResponseData } = await searchForCourses("english");
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(isSuccessfulSearch).toEqual(true);
+        expect(searchResponseData.numberOfMatches).toEqual(1);
+    });
+});

--- a/src/utils/searchForCourses.js
+++ b/src/utils/searchForCourses.js
@@ -1,0 +1,20 @@
+const searchForCourses = async (searchTerm) => {
+    const courseSearchUrl = `${process.env.COURSES_API_BASEURL}?search=${searchTerm}&max=${process.env.COURSES_API_MAX_RESULTS}`;
+
+    let isSuccessfulSearch;
+    let searchResponseData;
+    const defaultResponse = { numberOfMatches: 0, results: [] };
+
+    try {
+        const response = await fetch(courseSearchUrl);
+        isSuccessfulSearch = response.ok;
+        searchResponseData = isSuccessfulSearch ? await response.json() : defaultResponse;
+    } catch {
+        isSuccessfulSearch = false;
+        searchResponseData = defaultResponse;
+    }
+
+    return { isSuccessfulSearch, searchResponseData };
+};
+
+export { searchForCourses };


### PR DESCRIPTION
This is the second of 2 alternative options for a refactor.

This one extracts the block of code that handles calling the Courses API out of getServerSideProps and into its own module, with its own tests, most of which have been moved over from `index.test.js`. This one makes `index.js` more concise - although it adds more code in total, because of the extra tests.

Do you prefer one or the other? Or neither?