### PR TITLE
CFIN-417 Improve Course Search response time

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,9 +38,20 @@ custom:
   domainName: ${env:DOMAIN_NAME, ''}
   sslCertificateArn: ${env:SSL_CERTIFICATE_ARN, ''}
 
-# Exclude next.js dependencies that are not needed at runtime
+# Exclude files and next.js dependencies that are not needed at runtime
 package:
   exclude:
+    - .*
+    - .github/**
+    - .idea/**
+    - docs/**
+    - src/**
+    - package.json
+    - package-lock.json
+    - README.md
+    - LICENSE
+    - setupTests.js
+    - jest.config.js
     - node_modules/@babel/**
     - node_modules/ally.js/**
     - node_modules/caniuse-lite/**

--- a/serverless.yml
+++ b/serverless.yml
@@ -85,6 +85,13 @@ package:
     - node_modules/tr46/**
     - node_modules/micromatch/**
     - node_modules/sharp/**
+    - node_modules/@ampproject/**
+    - node_modules/postcss-modules-parser/**
+    - node_modules/css-modules-loader-core/**
+    - node_modules/babel-plugin-react-css-modules/**
+    - node_modules/es-abstract/**
+    - node_modules/string.prototype.trimstart/**
+    - node_modules/string.prototype.trimend/**
 
 resources:
   Conditions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ provider:
   region: eu-west-1
   # This role is required to deploy an application to AWS with an ESG Account. See https://wiki.york.ac.uk/display/AWS/AWS%3A+Github+Actions for details.
   cfnRole: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/GithubActionsDeploymentRole
-  memorySize: 1024
+  memorySize: 256
   environment:
     NODE_ENV: production
   stackTags:

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ provider:
   region: eu-west-1
   # This role is required to deploy an application to AWS with an ESG Account. See https://wiki.york.ac.uk/display/AWS/AWS%3A+Github+Actions for details.
   cfnRole: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/GithubActionsDeploymentRole
-  memorySize: 256
+  memorySize: 1024
   environment:
     NODE_ENV: production
   stackTags:


### PR DESCRIPTION
This is the result of an investigation to see if we can improve the response time of the Course Search application (purely focused on the front-end - other investigations into the Courses API and Funnelback are happening separately). I looked at package size and memory/CPU allocation. 

In short, **there's no noticeable effect on the average performance score when altering package size or memory/CPU allocation**, but I think the changes are worth doing for other reasons (deployment time and cost) so I'm raising this PR.

## Package size

- I identified a number of files that are currently packaged up that aren't necessary in the lambda, and added exclude rules for them.
- I identified a few more of the larger `node_modules` runtime dependencies (>=~1MB) that we don't appear to be using, and added exclude rules for these too.

The average performance score after this (plus all of the previous optimisations) was **88.55**, which is essentially unchanged from the **88** reported previously.

## Memory/CPU allocation

I also investigated Memory/CPU allocation. You can see the [full stats](https://docs.google.com/spreadsheets/d/19WKDGuomFVoVoBKuYMaQiZPZmDF3Quk7M6Gqo-rYPN8/edit#gid=0), but in summary:

| | 128MB | 256MB | 1024MB | 3008MB |
| --- | --- | --- | --- | --- |
| **Average performance score** | 85.2 | 88.95 | 88.55 | 88.7 |

The results indicate that we can lower our costs by decreasing the lambda size to 256MB with no noticeable effect on performance.