### PR TITLE
CFIN-409: Compress API responses > 1Kb

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,6 +19,8 @@ provider:
     defined_in: serverless
     repo_name: uoy-app-course-search
     team: "ESG Teaching and Learning"
+  apiGateway:
+    minimumCompressionSize: 1000
 
 functions:
   server:


### PR DESCRIPTION
One of the opportunities for optimising performance suggested by Lighthouse is to enable text compression. There is a trade off between the transmission speed gains from smaller files vs the overhead of doing the compression, which is why this change only compresses responses above a certain size (1000 bytes), aligning with what AWS CloudFront does (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html).

Lightspeed average score before change: 51
Lightspeed average score after change: 62
Lightspeed average score compress all responses:  60