### PR TITLE
Run visual testing on push to dev

### DIFF
--- a/.github/workflows/percy-visual-testing.yml
+++ b/.github/workflows/percy-visual-testing.yml
@@ -2,6 +2,9 @@ name: Run visual tests with Percy
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - dev
 
 jobs:
   visual-tests:

--- a/src/tests/visual/percyVisualTesting.js
+++ b/src/tests/visual/percyVisualTesting.js
@@ -2,6 +2,11 @@ const PercyScript = require("@percy/script");
 
 PercyScript.run(async (page, percySnapshot) => {
     await page.goto("http://localhost:3000/?search=maths");
+
     await page.waitForTimeout(100).then(".c-footer-main__heading");
+
     await percySnapshot("search page");
+
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit();
 });


### PR DESCRIPTION
Two things I noticed when testing Percy:

- We don't take snapshots when pushing to our default branch - future branches won't compare changes against the correct base snapshot unless we do this.
- For whatever reason the Percy script still runs forever on my local machine unless `process.exit()` is present - I saw no harm in adding it so that it will hopefully work for everyone.