### PR TITLE
CFIN-379 Make course titles weightier

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -35,3 +35,7 @@
     margin: 0;
     line-height: 1.45;
 }
+
+h2.c-listings-item__title {
+    font-weight: bold;
+}


### PR DESCRIPTION
The prototype shows the Course titles as 
` font weight: 700, font-size: 24px`
Before this change, our version had
`font weight: 400, font-size: 24px `

The html for the course title is
`<h2 className="c-listings-item__title">{title(course)}</h2>`

\<h2> in the university stylesheet has a font weight of bold, but the c-listings-item__title class font weight of 400 was winning out. So the prototype already conforms to the university styles, just the implementation not working.

The solution has been to create a specific `h2.c-listings-item__title` entry in the styles.css.
