### PR TITLE
Update lighthouse performance check to align mobile/desktop targets to 90

### DIFF
--- a/src/tests/performance/lighthouseTesting.js
+++ b/src/tests/performance/lighthouseTesting.js
@@ -8,7 +8,7 @@ const desktopConfig = require("lighthouse/lighthouse-core/config/lr-desktop-conf
 const TEST_URL = "http://localhost:3000?search=maths";
 const ITERATIONS = 5;
 const MINIMUM_DESKTOP_SCORE = 90;
-const MINIMUM_MOBILE_SCORE = 80;
+const MINIMUM_MOBILE_SCORE = 90;
 
 (async () => {
     const isMobileReport = process.argv.includes("--mobile");


### PR DESCRIPTION
I've noticed that the lighthouse performance checks for mobile are consistently scoring above 90 when running in a GitHub workflow and locally ([94 in this PR](https://github.com/university-of-york/uoy-app-course-search/runs/1987262692?check_suite_focus=true)).

I think we should be aiming to maintain this high mobile performance. It also feels nice to have a consistent performance target for mobile and desktop.