### PR TITLE
CFIN-450 Make the accessibility tree course links be the course title and award

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6586,9 +6586,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001153",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001153.tgz",
-      "integrity": "sha512-qv14w7kWwm2IW7DBvAKWlCqGTmV2XxNtSejJBVplwRjhkohHuhRUpeSlPjtu9erru0+A12zCDUiSmvx/AcqVRA=="
+      "version": "1.0.30001211",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz",
+      "integrity": "sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg=="
     },
     "canonicalize": {
       "version": "1.0.3",

--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -11,12 +11,12 @@ const Course = ({ course }) => {
         return course.title;
     };
 
-    const linkId = "course-title-" + title(course).replace(/ /g, "-");
+    const headingId = "course-title-" + title(course).replace(/ /g, "-");
 
     return (
         <li className="c-listings-item ">
-            <a className="c-listings-item__link" aria-labelledby={linkId} href={course.liveUrl}>
-                <h2 id={linkId} className="c-listings-item__title">
+            <a className="c-listings-item__link" aria-labelledby={headingId} href={course.liveUrl}>
+                <h2 id={headingId} className="c-listings-item__title">
                     {title(course)}
                 </h2>
                 <div className="c-listings-item__description">

--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -11,10 +11,14 @@ const Course = ({ course }) => {
         return course.title;
     };
 
+    const linkId = "course-title-" + title(course).replace(/ /g, "-");
+
     return (
         <li className="c-listings-item ">
-            <a className="c-listings-item__link" href={course.liveUrl}>
-                <h2 className="c-listings-item__title">{title(course)}</h2>
+            <a className="c-listings-item__link" aria-labelledby={linkId} href={course.liveUrl}>
+                <h2 id={linkId} className="c-listings-item__title">
+                    {title(course)}
+                </h2>
                 <div className="c-listings-item__description">
                     <CourseDetails course={course} />
                 </div>

--- a/src/tests/components/Course.test.js
+++ b/src/tests/components/Course.test.js
@@ -43,7 +43,7 @@ describe("Course", () => {
         expect(within(link).getByTestId("tag-icon")).toBeInTheDocument();
     });
 
-    it("uses the course title plus award as the link name", async () => {
+    it("uses the course title plus award as the accessibility tree link name, when award is present", async () => {
         const course = {
             title: "A Course",
             liveUrl: "https://fakecourse.notadomain/",
@@ -54,5 +54,17 @@ describe("Course", () => {
         render(<Course course={course} />);
 
         expect(screen.getByRole("link", { name: "A Course - Award" })).toBeInTheDocument();
+    });
+
+    it("the the accessibility tree link name is generated ok when award is not present", async () => {
+        const course = {
+            title: "A Course",
+            liveUrl: "https://fakecourse.notadomain/",
+            level: "undergraduate",
+        };
+
+        render(<Course course={course} />);
+
+        expect(screen.getByRole("link", { name: "A Course" })).toBeInTheDocument();
     });
 });

--- a/src/tests/components/Course.test.js
+++ b/src/tests/components/Course.test.js
@@ -42,4 +42,17 @@ describe("Course", () => {
         expect(within(link).getByRole("heading", { name: "A Course - Award" })).toBeInTheDocument();
         expect(within(link).getByTestId("tag-icon")).toBeInTheDocument();
     });
+
+    it("uses the course title plus award as the link name", async () => {
+        const course = {
+            title: "A Course",
+            liveUrl: "https://fakecourse.notadomain/",
+            level: "undergraduate",
+            award: "Award",
+        };
+
+        render(<Course course={course} />);
+
+        expect(screen.getByRole("link", { name: "A Course - Award" })).toBeInTheDocument();
+    });
 });

--- a/src/tests/components/Course.test.js
+++ b/src/tests/components/Course.test.js
@@ -56,7 +56,7 @@ describe("Course", () => {
         expect(screen.getByRole("link", { name: "A Course - Award" })).toBeInTheDocument();
     });
 
-    it("the the accessibility tree link name is generated ok when award is not present", async () => {
+    it("the accessibility tree link name is generated ok when award is not present", async () => {
         const course = {
             title: "A Course",
             liveUrl: "https://fakecourse.notadomain/",


### PR DESCRIPTION
The course links until this change have appeared in the accessibility tree with link text containing the course's title and all of its tags eg. 'Music - BA (Hons) Undergraduate BA (Hons) Start 2021 3 years full-time'

This change makes it 'Music - BA (Hons)'.

With grateful acknowledgement of Fergus's detailed notes on the JIRA story of how to tackle this.