### PR TITLE
Use calendar icon for course start rather than clock

### DIFF
--- a/src/components/CourseDetails.js
+++ b/src/components/CourseDetails.js
@@ -34,7 +34,7 @@ LevelAndAwardTag.propTypes = {
 const StartDateAndLengthTag = ({ yearOfEntry, length }) => {
     if (yearOfEntry || length) {
         const startYear = yearOfEntry ? `Start ${yearOfEntry.slice(0, 4)}` : null;
-        return <RichTag topIcon="clock-o" title={startYear} subText={length} />;
+        return <RichTag topIcon="calendar" title={startYear} subText={length} />;
     }
 
     return null;

--- a/src/tests/components/CourseDetails.test.js
+++ b/src/tests/components/CourseDetails.test.js
@@ -75,7 +75,7 @@ describe("Course details", () => {
 
         expect(tag[0]).toHaveTextContent("Start 2021");
         expect(tag[0]).toHaveTextContent("4 years full-time");
-        expect(within(tag[0]).getByTestId("tag-icon")).toHaveClass("c-icon--clock-o");
+        expect(within(tag[0]).getByTestId("tag-icon")).toHaveClass("c-icon--calendar");
     });
 
     it("displays tag with start year and length of course when only year of entry is present", () => {
@@ -88,7 +88,7 @@ describe("Course details", () => {
         const tag = screen.getAllByRole("listitem");
 
         expect(tag[0]).toHaveTextContent(/^Start 2021$/); // exactly matching 'Start 2021'
-        expect(within(tag[0]).getByTestId("tag-icon")).toHaveClass("c-icon--clock-o");
+        expect(within(tag[0]).getByTestId("tag-icon")).toHaveClass("c-icon--calendar");
     });
 
     it("displays tag with start year and length of course only length is present", () => {
@@ -101,7 +101,7 @@ describe("Course details", () => {
         const tag = screen.getAllByRole("listitem");
 
         expect(tag[0]).toHaveTextContent(/^4 years full-time$/); // exactly matching '4 years full-time'
-        expect(within(tag[0]).getByTestId("tag-icon")).toHaveClass("c-icon--clock-o");
+        expect(within(tag[0]).getByTestId("tag-icon")).toHaveClass("c-icon--calendar");
     });
 
     it("does not display tag with start year and length of course when neither are present", () => {


### PR DESCRIPTION
This came up at the stakeholder meeting - Paul Armstrong requested this change, and I tend to agree that a calendar is more appropriate for a date than a clock. 

Here's how it looks:
![image](https://user-images.githubusercontent.com/62424514/117039368-98cb5600-ad00-11eb-91e7-1da2770aae9e.png)

What do we think?