### PR TITLE
CFIN-509: Allow 'q' query param as synonym for 'search'

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -81,7 +81,7 @@ App.propTypes = {
 };
 
 const getServerSideProps = async (context) => {
-    const searchTerm = context.query.search;
+    const searchTerm = context.query.search === undefined ? context.query.q : context.query.search;
 
     if (noSearchConducted(searchTerm)) {
         return { props: {} };

--- a/src/tests/pages/index.test.js
+++ b/src/tests/pages/index.test.js
@@ -139,4 +139,16 @@ describe("getServerSideProps", () => {
         expect(response.props.searchResults).toEqual([]);
         expect(response.props.numberOfMatches).toEqual(0);
     });
+
+    it("can handle query parameter 'q' as synonym for 'search'", async () => {
+        searchForCourses.mockResolvedValue({
+            isSuccessfulSearch: true,
+            searchResponseData: { numberOfMatches: 0, results: [] },
+        });
+
+        await getServerSideProps({ query: { q: "biology" } });
+
+        expect(searchForCourses).toHaveBeenCalledTimes(1);
+        expect(searchForCourses).toHaveBeenCalledWith("biology");
+    });
 });


### PR DESCRIPTION
This is to allow Course Search to accept the same query parameter as Course Finder, so that it can be used as a variant in a Google Optimize redirect test.