### PR TITLE
Condense the README and add GitHub status badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,14 @@
-name: Run Prettier and XO checks, and tests
+name: build
+
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - dev
 
 jobs:
-  run-checks:
+  deploy_to_aws:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code
@@ -23,11 +27,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Check code is formatted correctly
-        run: npm run checkformat
-
-      - name: Check code conforms to linting rules
-        run: npm run lint
-
       - name: Check tests run
-        run: npm run test
+        run: npm run package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - dev
 
 jobs:
-  deploy_to_aws:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code
@@ -27,5 +27,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Check tests run
-        run: npm run package
+      - name: Run build
+        run: npm run build

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -8,7 +8,7 @@ on:
       - dev
 
 jobs:
-  run-checks:
+  check-format:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,0 +1,31 @@
+name: code formatting
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+jobs:
+  run-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the application's source code
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com
+          scope: "@university-of-york"
+          always-auth: true
+
+      - name: Install application dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Check code is formatted correctly
+        run: npm run checkformat

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  deploy_to_aws:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,11 +1,11 @@
-name: Deploy to AWS
+name: deployment
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - dev
       - main
-  workflow_dispatch:
 
 jobs:
   deploy_to_aws:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ on:
       - dev
 
 jobs:
-  run-checks:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,31 @@
+name: linting
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+jobs:
+  run-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the application's source code
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com
+          scope: "@university-of-york"
+          always-auth: true
+
+      - name: Install application dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Check code conforms to linting rules
+        run: npm run lint

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,6 +1,8 @@
-name: Report Package Size
+name: package size
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/performance-checks.yml
+++ b/.github/workflows/performance-checks.yml
@@ -8,7 +8,7 @@ on:
       - dev
 
 jobs:
-  performance-tests:
+  performance-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code

--- a/.github/workflows/performance-checks.yml
+++ b/.github/workflows/performance-checks.yml
@@ -1,7 +1,11 @@
-name: Run performance tests with Lighthouse
+name: performance checks
+
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - dev
 
 jobs:
   performance-tests:

--- a/.github/workflows/publish-architecture.yml
+++ b/.github/workflows/publish-architecture.yml
@@ -1,12 +1,12 @@
-name: "Publish C4 Model"
+name: publish architecture
 
 on:
+  workflow_dispatch:
   push:
     branches:
-    - main
+    - dev
     paths:
     - 'docs/architecture/*.dsl'
-  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-architecture.yml
+++ b/.github/workflows/publish-architecture.yml
@@ -4,35 +4,35 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - dev
+      - dev
     paths:
-    - 'docs/architecture/*.dsl'
+      - "docs/architecture/*.dsl"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Generate C4 Model
-      uses: university-of-york/generate-c4-model-action@1.0.0
-      with:
-        source-path: docs/architecture/c4-model.dsl
-        target-path: .github/actions/dist/images/c4
+      - name: Generate C4 Model
+        uses: university-of-york/generate-c4-model-action@1.0.0
+        with:
+          source-path: docs/architecture/c4-model.dsl
+          target-path: .github/actions/dist/images/c4
 
-    - name: Upload C4 Model Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: C4 Model
-        path: .github/actions/dist/images/c4/*.png
+      - name: Upload C4 Model Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: C4 Model
+          path: .github/actions/dist/images/c4/*.png
 
-    - name: Publish C4 Model to Wiki
-      uses: university-of-york/github-wiki-publish-action@2.0.0
-      with:
-        source-path: ./.github/actions/dist/images
-        target-path: ./images
-        delete-existing: true
-      env:
-        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Publish C4 Model to Wiki
+        uses: university-of-york/github-wiki-publish-action@2.0.0
+        with:
+          source-path: ./.github/actions/dist/images
+          target-path: ./images
+          delete-existing: true
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,14 @@
-name: Run visual tests with Percy
+name: tests
+
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - dev
 
 jobs:
-  visual-tests:
+  run-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code
@@ -26,16 +27,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Build the application
-        run: npm run build
-
-      - name: Run the application in the background
-        run: (npm start &)
-
-      - name: Wait for the application to start
-        run: sleep 10
-
-      - name: Run percy visual tests
-        run: npm run percy
-        env:
-          PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}
+      - name: Check tests run
+        run: npm run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
       - dev
 
 jobs:
-  run-checks:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the application's source code

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -1,0 +1,42 @@
+name: visual tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+jobs:
+  visual-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the application's source code
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com
+          scope: "@university-of-york"
+          always-auth: true
+
+      - name: Install application dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Build the application
+        run: npm run build
+
+      - name: Run the application in the background
+        run: (npm start &)
+
+      - name: Wait for the application to start
+        run: sleep 10
+
+      - name: Run percy visual tests
+        run: npm run percy
+        env:
+          PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm test
 
 ### Visual tests
 
-We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing. This adds snapshots of UI changes to each pull request. More detail can be found in the York Wiki Service page (University users only): [Testing: Percy, automation in testing with GitHub](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899)
+We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing. This adds snapshots of UI changes to each pull request.
 
 ### Performance tests
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ Deployment to the development and production environments happens through GitHub
 
 ### Deploying to your own AWS account
 
-You can run Course Search in your own AWS account. Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`) and then run:
+You can run Course Search in your own AWS account. You will need to do the following:
+
+- Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`)
+- Define an environment variable called `AWS_ACCOUNT_ID` populated with your AWS account ID
+   
+Then run:
 
 ```
 npm run deploy:dev
@@ -64,100 +69,19 @@ If you want to deploy a version that queries the production version of the Cours
 npm run deploy
 ```
 
-## Code style
-
-The project defines rules for code formatting and style. Code is checked against these
-rules upon creation of a pull request, configured in `.github/workflows/checks.yml`, 
-and upon a merge into `dev` or `main` branches on Github as part of `.github/workflows/deploy.yml`
-
-## Formatting
-
-This project uses [prettier](https://prettier.io/) to format code and to check that code
-is correctly formatted. Overrides to its default formatting rules are agreed by the team and
-configured in `.prettierrc.json` in the root folder. You can use `npm run format` to format
-all code in the project.
-
-##### Intellij
-
-You can configure Intellij to format code, using `prettier`, when you save a file and when 
-you run Intellij's formatting command (`Ctrl-Alt-L`). To do this:
-* install the `prettier` plugin (under `File` > `Settings` > `Plugins`)
-* go to `File` > `Settings` > `Languages & Frameworks` > `Javascript` > `Prettier` and
-check the options `on save` and `on code reformat`
-
-To make Intellij use the `prettier` formatting rules while you edit code, open
-`package.json` and above the code window it will prompt you to `Use code style based on prettier for this project?`
-which you can accept.
-
-#### Linting
-
-This project uses [XO](https://github.com/xojs/xo) to check code style. 
-XO is based on [ESLint](https://eslint.org/). Overrides to default linting rules are agreed
-by the team and configured in `.xo-config.json` in the root folder. You can use `npm run lint`
-to check whether the code conforms to the linting rules.
-
-### Useful commands
-
-**`npm run dev`**
-
-Start the application locally (running at http://localhost:3000 by default).
-
-**`npm run build`**
-
-Build the application. The build folder is `.next`.
-
-**`npm run start`**
-
-Start the application that has been built. This will use the code in the `.next` folder rather than the current source code.
-
-**`npm run deploy`**
-
-Deploy the application to AWS. To deploy to your AWS sandbox, you will need to 
-* be logged in to AWS using [saml2aws](https://wiki.york.ac.uk/display/AWS/2.+Command+Line+Access)
-* have defined an environment variable called `AWS_ACCOUNT_ID` with the account id of your sandbox:
+To undeploy the application from your AWS account:
 
 ```
-set AWS_ACCOUNT_ID=012345678
+npm run undeploy
 ```
 
-You can find your sandbox AWS account id by logging in to AWS either via
-the web console or via saml2aws - it is displayed when you select which
-account you want to use.
+## Code formatting and linting
 
-This will deploy the app using production environment variables (configured in
-`.env.production`).
+This project uses [prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for static analysis. To run these checks:
 
-**`npm run deploy:dev`**
-
-As above, but will use development environment variables (configured in `.env.development`).
-
-**`npm run undeploy`**
-
-Remove the application from AWS.
-
-**`npm run test`**
-
-Run the application's tests.
-
-**`npm run format`**
-
-Format all code using the team's agreed formatting rules. This uses `prettier`.
-
-**`npm run checkformat`**
-
-Check all code is correctly formatted according to agreed rules. Uses `prettier`.
-
-**`npm run lint`**
-
-Check to see if code meets the team's agreed coding standards. This uses `XO` (which in turn uses `eslint`).
-
-**`npm run check`**
-
-Checks code formatting (`prettier`), checks coding standards (`XO`), then runs tests.
-
-**`npm run formatandcheck`**
-
-Fixes code formatting (`prettier`), checks coding standards (`XO`), then runs tests.
+```
+npm run fc
+```
 
 ## TroubleShooting
 

--- a/README.md
+++ b/README.md
@@ -71,15 +71,10 @@ You can run Course Search in your own AWS account. You will need to do the follo
 - Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`)
 - Define an environment variable called `AWS_ACCOUNT_ID` populated with your AWS account ID
    
-Then run:
+Then run one of the following, depending on whether you want to query the development or production version of the Courses API:
 
 ```
 npm run deploy:dev
-```
-
-If you want to deploy a version that queries the production version of the Courses API, run:
-
-```
 npm run deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ using [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a
 
 ## Contact
 
-- [Digital Platforms and Developments Team](mailto:marketing-support@york.ac.uk)
-- [Enterprise Systems Teaching and Learning Team](mailto:esg-teaching-and-learning-group@york.ac.uk)
+- [Digital Services Teaching and Learning Service Delivery Team](mailto:esg-teaching-and-learning-group@york.ac.uk)
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # Course Search (not yet released)
+
+[![build](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/build.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/build.yml)
+[![tests](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/tests.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/tests.yml)
+[![code formatting](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/code-formatting.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/code-formatting.yml)
+[![linting](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/linting.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/linting.yml)
+[![performance checks](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/performance-checks.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/performance-checks.yml)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/ad91c322/uoy-app-course-search)
 
 This is the University of York's Course Search application. It allows prospective students to search for courses,

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
-# Course Search
+# Course Search (not yet released)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/ad91c322/uoy-app-course-search)
 
 This is the University of York's Course Search application. It allows prospective students to search for courses,
-view results, and follow links to course pages.
-
-See our [GitHub Wiki](https://github.com/university-of-york/uoy-app-course-search/wiki) for architectural decisions and related developer guides.
-
-**This project is a work-in-progress and search results may not meet expectations**
-
-Live URL: https://courses.app.york.ac.uk/
-Dev URL: https://courses.dev.app.york.ac.uk/
+view results, and follow links to course pages. 
+Both the [live system](https://courses.app.york.ac.uk/) and a [test system](https://courses.dev.app.york.ac.uk/) are available.
 
 ## Related Repos
 
@@ -17,77 +11,56 @@ Dev URL: https://courses.dev.app.york.ac.uk/
 - [Funnelback Courses API](https://github.com/university-of-york/uoy-config-funnelback-courses) - the underlying Funnelback search provider configuration that powers searches.
 - [Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) - suite of React components for incorporating university style into the application.
 
+
 ## Development
+
+See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki) for architectural decisions and related developer guides.
 
 ### Prerequisites
 
-You will need [Node.js](https://nodejs.org/en/download/) (LTS version) installed on your machine.
+ - You will need [Node.js](https://nodejs.org/en/download/) (v12) installed on your machine.
+ - You will need to have configured a `.npmrc` file with a GitHub token that has read access to packages from the [Digital Services Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) library.
 
 ### Local Development
 
 This application uses [Next.js](https://nextjs.org/). The entry point
-for the application is `src/pages/index.js`. To run the
-application locally in development mode using the command line:
+for the application is `src/pages/index.js`. 
+
+#### Command line
+
+To run the application locally in development mode using the command line:
 
 ```
 npm run dev
 ```
 
-Alternatively, in Intellij, open the `npm` window (right click
-on `package.json` and select `Show npm scripts`) and double-click on
-`dev`.
+#### IntelliJ IDEA
 
-Go to [http://localhost:3000](http://localhost:3000)
-to use the application.
+Open the `npm` window (right click on `package.json` and select `Show npm scripts`) and double-click on `dev`.
 
-To stop the application, on the command line press `ctrl-c`, or in
-Intellij, press the square red `Stop` button.
+Navigate to [http://localhost:3000](http://localhost:3000) to use the application.
 
-#### Pattern Library dependency requires `.npmrc`
-
-The application has a dependency on [ESG Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components).
-Fetching this dependency requires the project to have appropriate credentials
-for the `@university-of-york` Github registry configured. 
-See the [Pattern Library README](https://github.com/university-of-york/esg-lib-pattern-library-react-components)
-for instructions on setting up a `.npmrc` file for this. Without it, running
-`npm install` may produce errors like:
-
-```
-npm ERR! 404 Not Found - GET https://registry.npmjs.org/@university-of-york%2fesg-lib-pattern-library-react-components - Not found
-npm ERR! 404
-npm ERR! 404  '@university-of-york/esg-lib-pattern-library-react-components@4.3.4' is not in the npm registry.
-```
-#### A pages/_app.js file exists so an internal css file can be used
-See the [Next Built-In CSS Support - Adding a Global Stylesheet](https://nextjs.org/docs/basic-features/built-in-css-support) documentation
 ### Testing
 
 Tests live in `src/tests`. To run them:
+
+#### Command line
 
 ```
 npm test
 ```
 
-Or, in Intellij, open the `npm` window and double-click on `test`, or in package.json, click on the green arrow next to the "test": "jest" entry.
+#### IntelliJ IDEA
 
-Tests are run automatically upon creation of a pull request, configured in `.github/workflows/checks.yml`, 
-and upon a merge into `dev` or `main` branches on Github as part of `.github/workflows/deploy.yml`
+Open the `npm` window and double-click on `test`, or in `package.json` click on the green arrow next to the `test` entry.
 
-#### Mobile devices testing
+#### Visual Testing 
 
-The application is tested against a number of mobile devices, both emulated and real.
-In the first instance developers use Google Chrome Developer Tools and then finally BrowserStack for testing. 
-The Wiki page [Testing course search rendering on mobile devices](https://github.com/university-of-york/uoy-app-course-search/wiki/Testing-Course-Search-Rendering-on-Mobile-Devices) has more detail on the process.
-
-#### Percy Visual Testing 
-
-The application has a GitHub workflow action so that at a Pull Request it is subject to visual testing using [Percy][Percy](https://percy.io/ad91c322/uoy-app-course-search). 
-Should a difference be detected, then approval is required using Percy prior to a merge. 
-More detail can be found in the York Wiki Service page (University users only): [Testing: Percy, automation in testing with GitHub](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899)
+We use [Percy][Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
 
 ### Deployment
 
-Deployment to the development and production environments happen through GitHub actions that trigger automatically when 
-new code is merged into the `dev` and `main` branches. 
+Deployment to the development and production environments happens through GitHub actions that trigger automatically when new code is merged into the `dev` and `main` branches. 
 
 ### Domain setup
 

--- a/README.md
+++ b/README.md
@@ -23,106 +23,54 @@ See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki)
 
 ### Local Development
 
-This application uses [Next.js](https://nextjs.org/). The entry point
-for the application is `src/pages/index.js`. 
+This application uses [Next.js](https://nextjs.org/). The entry point for the application is `src/pages/index.js`.
 
-#### Command line
+Once started, the system is accessible at [http://localhost:3000](http://localhost:3000).
 
-To run the application locally in development mode using the command line:
+#### Run via command line
 
 ```
 npm run dev
 ```
 
-#### IntelliJ IDEA
+#### Run via IntelliJ IDEA
 
 Open the `npm` window (right click on `package.json` and select `Show npm scripts`) and double-click on `dev`.
-
-Navigate to [http://localhost:3000](http://localhost:3000) to use the application.
 
 ### Testing
 
 Tests live in `src/tests`. To run them:
 
-#### Command line
+#### Run via command line
 
 ```
 npm test
 ```
 
-#### IntelliJ IDEA
+#### Run via IntelliJ IDEA
 
 Open the `npm` window and double-click on `test`, or in `package.json` click on the green arrow next to the `test` entry.
 
 #### Visual Testing 
 
-We use [Percy][Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
+Thi repo uses [Percy][Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
 
 ### Deployment
 
-Deployment to the development and production environments happens through GitHub actions that trigger automatically when new code is merged into the `dev` and `main` branches. 
+Deployment to the development and production environments happens through GitHub actions that trigger automatically when new code is merged into the `dev` and `main` branches. See the [deployment wiki page](https://github.com/university-of-york/uoy-app-course-search/wiki/Deployment) for more details.
 
-### Domain setup
+#### Deploying to your own AWS account
 
-This application is automatically deployed to a custom domain by serverless and CloudFormation
-if the environment is appropriately configured (by setting environment variables `DOMAIN_NAME`
-and `SSL_CERTIFICATE_ARN`). For local sandbox development, you are unlikely to need to use a
-custom domain name, and therefore don't need to set these environment variables. For `dev` and 
-`production` environments, these environment variables are populated as part of the CI/CD 
-pipeline in `.github/workflows/deploy.yml`, though the sensitive values are stored securely 
-in the `Secrets` section of the GitHub repo settings.
+You can run Course Search in your own AWS sandbox. Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`) and then run:
 
-Provided that the [SSL certificate has been provisioned beforehand](https://github.com/university-of-york/uoy-app-course-search/wiki/Creating-and-Validating-an-SSL-Certificate-in-AWS),
-serverless will do all the work necessary to set up the environment, as detailed in `serverless.yml`. This involves setting up a custom domain name
-in API Gateway and mapping this to the API endpoint that serves our Next.js application. 
+```
+npm run deploy:dev
+```
+If you want to deploy a version that queries the production version of the Courses API, run:
 
-### Development and production environments
-
-Development environment variables are configured in `.env.development` and production
-environment variables are configured in `.env.production`. 
-The CI/CD pipeline is configured so that pushes to the `dev` branch will trigger a
-deployment to the ESG development AWS account using development environment variables,
-and pushes to the `main` branch will trigger a deployment to the ESG production AWS account
-using production environment variables.
-
-For local development, environment variables can be overridden by creating 
-`.env.development.local` and `.env.production.local`. These files will be ignored by Git.
-
-When running in AWS Lambda, this application's environment variables are set in Lambda
-by Serverless during the deployment process, thanks to the
-[Serverless dotenv plugin](https://www.serverless.com/plugins/serverless-dotenv-plugin).
-
-#### Switching between development and production Courses API
-
-This application fetches course data using the [Courses API](https://github.com/university-of-york/uoy-api-courses).
-Its URL is configured as an environment variable so that each deployment can use 
-the appropriate Courses API version. The development and production versions of 
-Course Search use the development and production versions of the Courses API respectively. 
-
-##### Local development
-
-When running Course Search locally using `npm run dev`, development environment variables
-will be used. To switch between development and
-production Courses API, create a file `.env.development.local` and add the production
-Courses API URL to it.
-
-##### Developer AWS sandbox
-
-When running Course Search in your AWS sandbox, use `npm run deploy` to deploy using
-production environment variables (and therefore the production Courses API), and 
-`npm run deploy:dev` to deploy using development environment variables (and
- therefore the development Courses API).
-
-##### courses.dev.app.york.ac.uk
-
-To change the development version of Course Search so that it uses the production version
-of the Courses API
-* checkout the `dev` branch of Course Search
-* log in to AWS using `saml2aws`
-* select the ESG Dev write user
-* run `npm run deploy`
-
-To change it back to using the development version of the Courses API, run `npm run deploy:dev`.
+```
+npm run deploy
+```
 
 ### Code style
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ We use the [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-
 
 To reinforce an accessibility-first approach, we use ARIA roles and reference these in automated tests where possible.
 
+## Code formatting and linting
+
+This project uses [prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for static analysis. To run these checks:
+
+```
+npm run fc
+```
+
 ## Deployment
 
 Deployment to the development and production environments happens through GitHub actions that trigger automatically when new code is merged into the `dev` and `main` branches. See the [deployment wiki page](https://github.com/university-of-york/uoy-app-course-search/wiki/Deployment) for more details.
@@ -79,14 +87,6 @@ To undeploy the application from your AWS account:
 
 ```
 npm run undeploy
-```
-
-## Code formatting and linting
-
-This project uses [prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for static analysis. To run these checks:
-
-```
-npm run fc
 ```
 
 ## TroubleShooting

--- a/README.md
+++ b/README.md
@@ -84,23 +84,6 @@ To undeploy the application from your AWS account:
 npm run undeploy
 ```
 
-## TroubleShooting
-
-### Logs
-Logs for the application can be found in CloudWatch. As an ESG AWS user for the relevant environment, open CloudWatch from the AWS Management console and click on `Log groups`. The group name is `/aws/lambda/uoy-app-course-search-v1-server`.
-
-This is the place to check if the application is experiencing weird errors, for example 
-```
-{
-message: "Internal server error"
-}
-```
-instead of a next error page or suspicious errors with nothing in the console.
-
-## Automated BugFixes (Dependabot)
-We have experienced issues with Dependabot updates breaking the application in the past. Before merging in an automated security 
-PR/Dependabot PR we should check out and deploy the code to a sandbox account, to ensure there aren't any breaking changes.
-
 ## Contact
 
 - [Digital Services Teaching and Learning Service Delivery Team](mailto:esg-teaching-and-learning-group@york.ac.uk)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To reinforce an accessibility-first approach, we use ARIA roles and reference th
 
 ## Code formatting and linting
 
-This project uses [prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for static analysis. To run these checks:
+This project uses [prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for linting. To run these checks:
 
 ```
 npm run fc

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is the University of York's Course Search application. It allows prospective students to search for courses,
 view results, and follow links to course pages. 
-Both the [live system](https://courses.app.york.ac.uk/) and a [test system](https://courses.dev.app.york.ac.uk/) are available.
+Both a [live system](https://courses.app.york.ac.uk/) and a [test system](https://courses.dev.app.york.ac.uk/) are available.
 
 See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki) for architectural decisions and developer guides.
 

--- a/README.md
+++ b/README.md
@@ -25,35 +25,25 @@ See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki)
 
 This application uses [Next.js](https://nextjs.org/). The entry point for the application is `src/pages/index.js`.
 
-Once started, the system is accessible at [http://localhost:3000](http://localhost:3000).
-
-#### Run via command line
+To run the application:
 
 ```
 npm run dev
 ```
 
-#### Run via IntelliJ IDEA
-
-Open the `npm` window (right click on `package.json` and select `Show npm scripts`) and double-click on `dev`.
+Once started, the system is accessible at [http://localhost:3000](http://localhost:3000).
 
 ### Testing
 
 Tests live in `src/tests`. To run them:
 
-#### Run via command line
-
 ```
 npm test
 ```
 
-#### Run via IntelliJ IDEA
-
-Open the `npm` window and double-click on `test`, or in `package.json` click on the green arrow next to the `test` entry.
-
 #### Visual Testing 
 
-Thi repo uses [Percy][Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
+Thi repo uses [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
 
 ### Deployment
 
@@ -61,11 +51,12 @@ Deployment to the development and production environments happens through GitHub
 
 #### Deploying to your own AWS account
 
-You can run Course Search in your own AWS sandbox. Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`) and then run:
+You can run Course Search in your own AWS account. Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`) and then run:
 
 ```
 npm run deploy:dev
 ```
+
 If you want to deploy a version that queries the production version of the Courses API, run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm test
 
 ### Visual tests
 
-We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request.
+We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing. This adds snapshots of UI changes to each pull request.
 
 ### Performance tests
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 [![code formatting](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/code-formatting.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/code-formatting.yml)
 [![linting](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/linting.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/linting.yml)
 [![performance checks](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/performance-checks.yml/badge.svg)](https://github.com/university-of-york/uoy-app-course-search/actions/workflows/performance-checks.yml)
+
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/ad91c322/uoy-app-course-search)
+[![GitHub](https://img.shields.io/github/license/university-of-york/uoy-app-course-search?color=blue)](https://github.com/university-of-york/uoy-app-course-search/blob/update-status-badges/LICENSE)
 
 This is the University of York's Course Search application. It allows prospective students to search for courses,
 view results, and follow links to course pages. 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm test
 
 ### Visual tests
 
-We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing. This adds snapshots of UI changes to each pull request.
+We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing. This adds snapshots of UI changes to each pull request. More detail can be found in the York Wiki Service page (University users only): [Testing: Percy, automation in testing with GitHub](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899)
 
 ### Performance tests
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm test
 
 #### Visual Testing 
 
-Thi repo uses [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
+This repo uses [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,3 @@ npm run undeploy
 ## Contact
 
 - [Digital Services Teaching and Learning Service Delivery Team](mailto:esg-teaching-and-learning-group@york.ac.uk)
-
-## Licence
-
-MIT

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki)
 
 - [Courses API](https://github.com/university-of-york/uoy-api-courses) - the API that provides Course Search functionality and in turn calls the Funnelback Courses API.
 - [Funnelback Courses API](https://github.com/university-of-york/uoy-config-funnelback-courses) - the underlying Funnelback search provider configuration that powers searches.
-- [Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) - suite of React components for incorporating university style into the application.
+- [Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) - a suite of React components for incorporating university style into the application.
 
 ## Dependencies
 
  - You will need [Node.js](https://nodejs.org/en/download/) (v12) installed on your machine.
- - You will need to have configured a `.npmrc` file with a GitHub token that has read access to packages from the [Digital Services Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) library.
+ - You will need to have configured a `.npmrc` file with a GitHub token that has read access to packages from [Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Both a [live system](https://courses.app.york.ac.uk/) and a [test system](https:
 
 See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki) for architectural decisions and developer guides.
 
-## Related Repos
+## Related repositories
 
 - [Courses API](https://github.com/university-of-york/uoy-api-courses) - the API that provides Course Search functionality and in turn calls the Funnelback Courses API.
 - [Funnelback Courses API](https://github.com/university-of-york/uoy-config-funnelback-courses) - the underlying Funnelback search provider configuration that powers searches.

--- a/README.md
+++ b/README.md
@@ -5,27 +5,24 @@ This is the University of York's Course Search application. It allows prospectiv
 view results, and follow links to course pages. 
 Both the [live system](https://courses.app.york.ac.uk/) and a [test system](https://courses.dev.app.york.ac.uk/) are available.
 
+See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki) for architectural decisions and developer guides.
+
 ## Related Repos
 
 - [Courses API](https://github.com/university-of-york/uoy-api-courses) - the API that provides Course Search functionality and in turn calls the Funnelback Courses API.
 - [Funnelback Courses API](https://github.com/university-of-york/uoy-config-funnelback-courses) - the underlying Funnelback search provider configuration that powers searches.
 - [Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) - suite of React components for incorporating university style into the application.
 
-
-## Development
-
-See the [wiki](https://github.com/university-of-york/uoy-app-course-search/wiki) for architectural decisions and related developer guides.
-
-### Prerequisites
+## Dependencies
 
  - You will need [Node.js](https://nodejs.org/en/download/) (v12) installed on your machine.
  - You will need to have configured a `.npmrc` file with a GitHub token that has read access to packages from the [Digital Services Pattern Library React Components](https://github.com/university-of-york/esg-lib-pattern-library-react-components) library.
 
-### Local Development
+## Development
 
 This application uses [Next.js](https://nextjs.org/). The entry point for the application is `src/pages/index.js`.
 
-To run the application:
+To build and run the application:
 
 ```
 npm run dev
@@ -33,7 +30,7 @@ npm run dev
 
 Once started, the system is accessible at [http://localhost:3000](http://localhost:3000).
 
-### Testing
+## Tests
 
 Tests live in `src/tests`. To run them:
 
@@ -41,15 +38,19 @@ Tests live in `src/tests`. To run them:
 npm test
 ```
 
-#### Visual Testing 
+### Visual tests
 
-This repo uses [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York Wiki page](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
+This repo uses [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York wiki](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
 
-### Deployment
+### Performance tests
+
+We use [Lighthouse](https://developers.google.com/web/tools/lighthouse/) to run performance tests against the application on each new build and pull request. Performance scores below 85 are marked as a failing build.
+
+## Deployment
 
 Deployment to the development and production environments happens through GitHub actions that trigger automatically when new code is merged into the `dev` and `main` branches. See the [deployment wiki page](https://github.com/university-of-york/uoy-app-course-search/wiki/Deployment) for more details.
 
-#### Deploying to your own AWS account
+### Deploying to your own AWS account
 
 You can run Course Search in your own AWS account. Make sure you've got an active token under `~/.aws/credentials` (e.g. by logging into your account with `saml2aws`) and then run:
 
@@ -63,13 +64,13 @@ If you want to deploy a version that queries the production version of the Cours
 npm run deploy
 ```
 
-### Code style
+## Code style
 
 The project defines rules for code formatting and style. Code is checked against these
 rules upon creation of a pull request, configured in `.github/workflows/checks.yml`, 
 and upon a merge into `dev` or `main` branches on Github as part of `.github/workflows/deploy.yml`
 
-#### Formatting
+## Formatting
 
 This project uses [prettier](https://prettier.io/) to format code and to check that code
 is correctly formatted. Overrides to its default formatting rules are agreed by the team and

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To reinforce an accessibility-first approach, we use ARIA roles and reference th
 
 ## Code formatting and linting
 
-This project uses [prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for linting. To run these checks:
+This project uses [Prettier](https://prettier.io/) for code formatting and [XO](https://github.com/xojs/xo) for linting. To format the code and run these checks:
 
 ```
 npm run fc

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once started, the system is accessible at [http://localhost:3000](http://localho
 
 ## Tests
 
-Tests live in `src/tests`. To run them:
+Automated tests live in `src/tests`. To run them:
 
 ```
 npm test
@@ -40,11 +40,17 @@ npm test
 
 ### Visual tests
 
-This repo uses [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request. More details can be found in the [University of York wiki](https://wiki.york.ac.uk/pages/viewpage.action?pageId=220921899) (University users only).
+We use [Percy](https://percy.io/ad91c322/uoy-app-course-search) for visual testing - this allows us to see UI changes as a result of each pull request.
 
 ### Performance tests
 
 We use [Lighthouse](https://developers.google.com/web/tools/lighthouse/) to run performance tests against the application on each new build and pull request. Performance scores below 85 are marked as a failing build.
+
+### Accessibility tests
+
+We use the [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) to perform basic accessibility checks. We also run manual accessibility tests against the application, including testing with users of assistive technologies.
+
+To reinforce an accessibility-first approach, we use ARIA roles and reference these in automated tests where possible.
 
 ## Deployment
 
@@ -99,11 +105,6 @@ instead of a next error page or suspicious errors with nothing in the console.
 ## Automated BugFixes (Dependabot)
 We have experienced issues with Dependabot updates breaking the application in the past. Before merging in an automated security 
 PR/Dependabot PR we should check out and deploy the code to a sandbox account, to ensure there aren't any breaking changes.
-
-## Accessibility
-
-The application's linting process checks for conformance to accessibility standards
-using [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y).
 
 ## Contact
 


### PR DESCRIPTION
Our README is very detailed, but I've felt overwhelmed by it for a while - times have moved on and we have more knowledge of AWS and npm, and the focus should be on being a getting started guide rather than a go-to for every single detail.

This PR is a (perhaps bold) suggestion to trim down the README to some of the essentials, with some information being moved to the GitHub wiki, and some being removed altogether.

At the same time I decided to tackle the GitHub workflows, opting to split out the checks into separate workflows - this gives us more visibility of exactly what goes wrong in a build, at the trade-off of spending more GitHub build minutes. I think it's worth the cost.

Splitting out the checks also makes it very easy to have a clean set of GitHub status badges that immediately tell us the health of the repo. These show the result of the checks being run against the `dev` branch.

You can see the rendered version of the readme [here](https://github.com/university-of-york/uoy-app-course-search/tree/update-readme). You can see how the updated checks appear by looking at this PR.

Thoughts welcome :slightly_smiling_face: 