### PR TITLE
Update c4 model

### DIFF
--- a/docs/architecture/c4-model.dsl
+++ b/docs/architecture/c4-model.dsl
@@ -3,26 +3,35 @@ workspace "Course Search" "A system to search for courses available at the Unive
     model {
         prospectiveStudent = person "Prospective Student" "A prospective student, searching for one or more courses"
 
-        courseSearch = softwareSystem "Course Search System" "Allows anyone to search for details of courses available at the University of York" {
+        courseSearch = softwareSystem "Course Search" "Allows anyone to search for details of courses available at the University of York" {
             webApplication = container "Web Application" "Provides functionality for users to search for courses in their web browser" "Next.js on AWS Lambda" "Web Browser"
             apiApplication = container "API" "Provides course search functionality via a JSON/HTTPS API" "AWS API Gateway and AWS Lambda"
         }
 
         # external software systems
-        searchProvider = softwareSystem "Funnelback Search Provider System" "The system that powers searches on YorkWeb" "Existing System"
-        cms = softwareSystem "Content Management System" "The system that provides the content for YorkWeb" "Existing System"
+        searchProvider = softwareSystem "Funnelback Search Engine" "The system that powers searches on the University of York website" "Existing System"
+        yorkWeb = softwareSystem "University of York website" "www.york.ac.uk, which hosts course pages and information" "Existing System" {
+            coursePages = container "Course Pages" "Course pages published on the University of York website"
+            externalCourses = container "External Courses Feed" "A feed of information for courses at partner institutions e.g. HYMS"
+        }
+        hyms = softwareSystem "HYMS website" "www.hyms.ac.uk, which hosts course pages and information" "Existing System"
 
         # system context relationships
         prospectiveStudent -> courseSearch "Searches for courses using"
         courseSearch -> searchProvider "Queries"
-        courseSearch -> cms "Links to pages in"
-        searchProvider -> cms "Indexes pages in"
+        courseSearch -> yorkWeb "Links to course pages on"
+        courseSearch -> hyms "Links to course pages on"
+        searchProvider -> yorkWeb "Indexes course information on"
 
         # container relationships
         prospectiveStudent -> webApplication "Searches for courses using" "HTTPS"
         webApplication -> apiApplication "Makes API calls to" "JSON/HTTPS"
-        webApplication -> cms "Links to pages in"
+        webApplication -> yorkWeb "Links to course pages on" "HTTPS"
+        webApplication -> hyms "Links to course pages on" "HTTPS"
         apiApplication -> searchProvider "Makes API calls to" "JSON/HTTPS"
+        
+        searchProvider -> coursePages "Indexes course information on" "HTTPS"
+        searchProvider -> externalCourses "Indexes course information in" "HTTPS"
     }
 
     views {
@@ -31,9 +40,14 @@ workspace "Course Search" "A system to search for courses available at the Unive
             autoLayout
         }
 
-        container courseSearch "Containers" {
+        container courseSearch "CourseSearchContainer" {
             include *
             autoLayout
+        }
+        
+        container yorkWeb "YorkWebContainer" {
+            include *
+            autoLayout lr
         }
 
         styles {


### PR DESCRIPTION
This PR updates the system architecture diagrams to better reflect the fact that course pages are on www.york.ac.uk, and includes a new container diagram which shows that the data sources are both the course pages and the external courses feed.

# System Context

![structurizr-SystemContext](https://user-images.githubusercontent.com/59824795/120512126-f7005d00-c3c2-11eb-989c-6b43898c79f5.png)

# Course Search Container

![structurizr-CourseSearchContainer](https://user-images.githubusercontent.com/59824795/120512150-fd8ed480-c3c2-11eb-93ea-f0f93bcdb71d.png)

# York Web Container

![structurizr-YorkWebContainer](https://user-images.githubusercontent.com/59824795/120512160-01225b80-c3c3-11eb-84ee-efcef5c12849.png)

