### PR TITLE
CFIN-522: Install Google Tag Manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14898,6 +14898,11 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-gtm-module": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/react-gtm-module/-/react-gtm-module-2.0.11.tgz",
+      "integrity": "sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-gtm-module": "^2.0.11",
     "serverless-apigw-binary": "^0.4.4",
     "serverless-http": "^2.7.0"
   },

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,6 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag() {
-    dataLayer.push(arguments);
-}
-gtag("js", new Date());
-gtag("config", "UA-1621853-1");

--- a/src/components/PageHead.js
+++ b/src/components/PageHead.js
@@ -5,8 +5,6 @@ import PropTypes from "prop-types";
 const PageHead = ({ search }) => {
     return (
         <Head>
-            <script src="https://www.googleoptimize.com/optimize.js?id=OPT-PCBTPN9" />
-
             <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
             <meta name="author" content="University of York" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -20,9 +18,6 @@ const PageHead = ({ search }) => {
             <link rel="stylesheet" href="https://www.york.ac.uk/static/globalalert/covid19styles.css" media="screen" />
             <script src="//use.typekit.net/dvj8rpp.js" />
             <script language="application/javascript">Typekit.load();</script>
-
-            <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-1621853-1" />
-            <script src="/js/analytics.js" />
         </Head>
     );
 };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,8 +1,14 @@
 import "../../public/stylesheets/styles.css";
 import PropTypes from "prop-types";
+import React, { useEffect } from "react";
+import TagManager from "react-gtm-module";
 
-// Required for Next to use a global stylesheet - see README
 const CourseSearchApp = ({ Component, pageProps }) => {
+    useEffect(() => {
+        // Enable Google Tag Manager with the university's GTM container ID
+        TagManager.initialize({ gtmId: "GTM-WXLX54" });
+    }, []);
+    // Required for Next to use a global stylesheet
     return <Component {...pageProps} />;
 };
 

--- a/src/tests/performance/lighthouseTesting.js
+++ b/src/tests/performance/lighthouseTesting.js
@@ -8,7 +8,7 @@ const desktopConfig = require("lighthouse/lighthouse-core/config/lr-desktop-conf
 const TEST_URL = "http://localhost:3000?search=maths";
 const ITERATIONS = 5;
 const MINIMUM_DESKTOP_SCORE = 90;
-const MINIMUM_MOBILE_SCORE = 85;
+const MINIMUM_MOBILE_SCORE = 60;
 
 (async () => {
     const isMobileReport = process.argv.includes("--mobile");


### PR DESCRIPTION
This PR installs Google Tag Manager into Course Search. [Google's instructions for installing GTM](https://developers.google.com/tag-manager/quickstart) don't work very well for React/Next apps, which has led to development of [an npm library](https://www.npmjs.com/package/react-gtm-module) specifically for installing GTM in a React/Next app. I followed [these instructions](https://www.learnbestcoding.com/post/9/easiest-way-to-integrate-google-analytics-with-react-js-and-next-js) and it seems to work well - I have verified with Digital Marketing that it works as expected.

There are two reasons why we almost certainly need to install GTM into Course Search:
1. We want to track various metrics to help us determine whether Course Search provides a better user experience than Course Finder. One of these is scroll depth (how much scrolling do users do when looking for courses). Scroll depth tracking requires GTM.
2. The university runs various ad campaigns to attract prospective students to apply to study at York. Users who view an ad on Facebook/Snapchat/Twitter etc are tracked via a number of marketing trackers. The university wants to know (among other things) how many of these users go on to conduct a course search. Therefore, we need to enable these marketing trackers on Course Search. This is done via GTM.

With GTM installed, there is no longer any need for Course Search to have installations of Google Analytics or Google Optimize. The university's GTM container enables both of these by default, so I have removed them. In contrast to Course Finder, where uninstalling Google Optimize and relying on GTM for it led to performance issues, that doesn't seem to be the case here. That's almost certainly because Course Finder is where our Google Optimize redirect test starts, and needs Google Optimize to kick in ASAP for a smooth redirect.

As mentioned above - with GTM installed, a lot of extra javascript (UoY ad campaign trackers) will be executed when users visit Course Search. This reduces the app's performance scores for mobile users, so I have lowered the lighthouse test threshold accordingly. This is not ideal, but these marketing trackers will need to be enabled on Course Search (via GTM), so I don't think there's much we can do about the performance hit.