### PR TITLE
CFIN-583: Remove Pino default fields

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -16,6 +16,10 @@ const logger = pino({
     serializers: {
         error: pino.stdSerializers.err,
     },
+    // Base controls what fields are included in the JSON
+    // object, by default Pino includes fields like pid which
+    // are not very relevant in a serverless context
+    base: {},
     // Whilst we could use `pino.stdTimeFunctions.isoTime`, it doesn't
     // have a key of `timestamp` which our logging format requires
     timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,


### PR DESCRIPTION
The fields `pid` and `hostname` are included by default in Pino, they aren't very useful to us since this application is serverless. This merge would remove the two fields from the logger output object.