### PR TITLE
CFIN-583: Add missing loggers

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -85,9 +85,13 @@ App.propTypes = {
 const getServerSideProps = async (context) => {
     const searchTerm = context.query.search === undefined ? context.query.q : context.query.search;
 
-    if (noSearchConducted(searchTerm)) return { props: {} };
+    if (noSearchConducted(searchTerm)) {
+        logger.info(logEntry(context.req, context.query, null), "User loaded courses index page");
+        return { props: {} };
+    }
 
     if (emptySearchConducted(searchTerm)) {
+        logger.info(logEntry(context.req, context.query, null), "User conducted an empty search");
         return { props: { searchTerm, isSuccessfulSearch: true, searchResults: [], numberOfMatches: 0 } };
     }
 


### PR DESCRIPTION
Noticed that I have forgotten to log when the user loads the courses index page and when they conduct an empty search. This functionality was previously available but I had moved the existing logger elsewhere. This PR hopefully fixes this oversight.